### PR TITLE
Fixed CI pipeline related errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_gem:
+  rubocop-discourse: stree-compat.yml

--- a/.streerc
+++ b/.streerc
@@ -1,0 +1,2 @@
+--print-width=100
+--plugins=plugin/trailing_comma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
-  x86_64-darwin-22
+  ruby
 
 DEPENDENCIES
   rubocop-discourse

--- a/app/controllers/landing_pages/admin/admin.rb
+++ b/app/controllers/landing_pages/admin/admin.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 class LandingPages::AdminController < ::Admin::AdminController
-
   private
 
   def check_page_exists
-    unless LandingPages::Page.exists?(params[:id])
-      raise Discourse::InvalidParameters.new(:id)
-    end
+    raise Discourse::InvalidParameters.new(:id) unless LandingPages::Page.exists?(params[:id])
   end
 
   def find_page
@@ -17,7 +14,7 @@ class LandingPages::AdminController < ::Admin::AdminController
     ActiveModel::ArraySerializer.new(
       LandingPages::Page.all,
       each_serializer: LandingPages::BasicPageSerializer,
-      root: false
+      root: false,
     )
   end
 
@@ -29,7 +26,7 @@ class LandingPages::AdminController < ::Admin::AdminController
     ActiveModel::ArraySerializer.new(
       LandingPages::Menu.all,
       each_serializer: LandingPages::MenuSerializer,
-      root: false
+      root: false,
     )
   end
 
@@ -43,9 +40,7 @@ class LandingPages::AdminController < ::Admin::AdminController
 
   def render_page(page, include_pages: false)
     if page.valid?
-      json = {
-        page: serialize_page(page)
-      }
+      json = { page: serialize_page(page) }
       json[:pages] = serialzed_pages if include_pages
       render_json_dump(json)
     else

--- a/app/controllers/landing_pages/admin/global.rb
+++ b/app/controllers/landing_pages/admin/global.rb
@@ -22,11 +22,6 @@ class LandingPages::GlobalsController < LandingPages::AdminController
   protected
 
   def global_params
-    params.require(:global)
-      .permit(
-        scripts: [],
-        header: {},
-        footer: {}
-      )
+    params.require(:global).permit(scripts: [], header: {}, footer: {})
   end
 end

--- a/app/controllers/landing_pages/admin/page.rb
+++ b/app/controllers/landing_pages/admin/page.rb
@@ -4,15 +4,15 @@ class LandingPages::PageController < LandingPages::AdminController
   skip_before_action :check_xhr, only: [:export]
 
   before_action :refresh_remote, only: [:index]
-  before_action :check_page_exists, only: [:show, :update, :destroy, :export]
-  before_action :find_page, only: [:show, :update, :export]
+  before_action :check_page_exists, only: %i[show update destroy export]
+  before_action :find_page, only: %i[show update export]
 
   def index
     render_json_dump(
       pages: serialzed_pages,
       menus: serialize_menus,
       remote: serialized_remote,
-      global: serialized_global
+      global: serialized_global,
     )
   end
 
@@ -44,10 +44,10 @@ class LandingPages::PageController < LandingPages::AdminController
     exporter = LandingPages::ZipExporter.new(@page)
     file_path = exporter.package_filename
 
-    headers['Content-Length'] = File.size(file_path).to_s
+    headers["Content-Length"] = File.size(file_path).to_s
     send_data File.read(file_path),
-      filename: File.basename(file_path),
-      content_type: "application/zip"
+              filename: File.basename(file_path),
+              content_type: "application/zip"
   ensure
     exporter.cleanup!
   end
@@ -67,17 +67,10 @@ class LandingPages::PageController < LandingPages::AdminController
   private
 
   def page_params
-    params.require(:page)
-      .permit(
-        :name,
-        :path,
-        :parent_id,
-        :category_id,
-        :theme_id,
-        :body,
-        :menu,
-        group_ids: []
-      ).to_h
+    params
+      .require(:page)
+      .permit(:name, :path, :parent_id, :category_id, :theme_id, :body, :menu, group_ids: [])
+      .to_h
   end
 
   def refresh_remote

--- a/app/controllers/landing_pages/admin/remote.rb
+++ b/app/controllers/landing_pages/admin/remote.rb
@@ -5,9 +5,8 @@ class LandingPages::RemotesController < LandingPages::AdminController
     remote = LandingPages::Remote.update(remote_params)
 
     if remote.valid?
-      render json: success_json.merge(
-        remote: LandingPages::RemoteSerializer.new(remote, root: false)
-      )
+      render json:
+               success_json.merge(remote: LandingPages::RemoteSerializer.new(remote, root: false))
     else
       render_json_error(remote)
     end
@@ -29,7 +28,7 @@ class LandingPages::RemotesController < LandingPages::AdminController
       report: importer.report,
       menus: serialize_menus,
       pages: serialzed_pages,
-      global: serialized_global
+      global: serialized_global,
     )
   end
 
@@ -49,9 +48,7 @@ class LandingPages::RemotesController < LandingPages::AdminController
     if remote.connected
       remote.reset
 
-      render json: {
-        commits_behind: remote.commits_behind
-      }
+      render json: { commits_behind: remote.commits_behind }
     else
       render json: failed_json
     end
@@ -60,12 +57,6 @@ class LandingPages::RemotesController < LandingPages::AdminController
   private
 
   def remote_params
-    params.require(:remote)
-      .permit(
-        :url,
-        :branch,
-        :public_key,
-        :private_key
-      )
+    params.require(:remote).permit(:url, :branch, :public_key, :private_key)
   end
 end

--- a/app/controllers/landing_pages/concerns/landing_helper.rb
+++ b/app/controllers/landing_pages/concerns/landing_helper.rb
@@ -1,49 +1,55 @@
 # frozen_string_literal: true
 module LandingHelper
-  def user_profile(user, include_avatar: true, add_bio: false, avatar_size: 90, top_extra: '', bottom_extra: '', profile_details: true, show_groups: [], show_location: false)
+  def user_profile(
+    user,
+    include_avatar: true,
+    add_bio: false,
+    avatar_size: 90,
+    top_extra: "",
+    bottom_extra: "",
+    profile_details: true,
+    show_groups: [],
+    show_location: false
+  )
     return nil if user.blank?
 
     user = User.find_by(username: username) if user.blank?
 
     if user
-      bio_html = ''
-      location_html = ''
-      group_html = ''
-      avatar_html = ''
-      profile_details_html = ''
+      bio_html = ""
+      location_html = ""
+      group_html = ""
+      avatar_html = ""
+      profile_details_html = ""
 
       if profile_details
-        if show_location && user.user_profile.location
-          location_html = <<~HTML.html_safe
-            <div class="user-location">#{SvgSprite.raw_svg('map-marker-alt')}<span>#{user.user_profile.location}</span></div>
+        location_html = <<~HTML.html_safe if show_location && user.user_profile.location
+            <div class="user-location">#{SvgSprite.raw_svg("map-marker-alt")}<span>#{user.user_profile.location}</span></div>
           HTML
-        end
 
         if show_groups
           user_groups = user.groups.where(name: show_groups)
 
-          if user_groups.present?
-            group_html = <<~HTML.html_safe
+          group_html = <<~HTML.html_safe if user_groups.present?
               <div class="user-groups">
                 #{user_groups.map { |g| "<span>#{g.full_name}</span>" }.join("")}
               </div>
             HTML
-          end
         end
 
-        profile_details_html = "<div class='user-profile-details'><div class='user-name'>#{user.readable_name}</div>#{group_html}#{location_html}</div>"
+        profile_details_html =
+          "<div class='user-profile-details'><div class='user-name'>#{user.readable_name}</div>#{group_html}#{location_html}</div>"
       end
 
-      if add_bio
-        bio_html = <<~HTML.html_safe
+      bio_html = <<~HTML.html_safe if add_bio
           <div class="user-bio">
             <a href="/u/#{user.username}">#{user.user_profile.bio_excerpt(375)}</a>
           </div>
         HTML
-      end
 
       if include_avatar
-        avatar_html = "<img width='#{(avatar_size / 2).to_s}' height='#{(avatar_size / 2).to_s}' src='#{user.avatar_template.gsub('{size}', avatar_size.to_s)}' class='avatar'>"
+        avatar_html =
+          "<img width='#{(avatar_size / 2).to_s}' height='#{(avatar_size / 2).to_s}' src='#{user.avatar_template.gsub("{size}", avatar_size.to_s)}' class='avatar'>"
       end
 
       <<~HTML.html_safe
@@ -53,10 +59,10 @@ module LandingHelper
               #{avatar_html}
               #{profile_details_html}
             </a>
-            <div class="top-extra">#{top_extra.present? ? top_extra : ''}</div>
+            <div class="top-extra">#{top_extra.present? ? top_extra : ""}</div>
           </div>
           #{bio_html}
-          #{bottom_extra.present? ? bottom_extra : ''}
+          #{bottom_extra.present? ? bottom_extra : ""}
         </div>
       HTML
     end
@@ -66,10 +72,11 @@ module LandingHelper
     if group_name
       group = Group.find_by(name: group_name)
 
-      if group && (
-        (group.visibility_level == Group.visibility_levels[:public]) ||
-        (@group && @group.id == group.id)
-      )
+      if group &&
+           (
+             (group.visibility_level == Group.visibility_levels[:public]) ||
+               (@group && @group.id == group.id)
+           )
         users = group.users
         users = users.order(ActiveRecord::Base.sanitize_sql_array([*order])) if order
         return users.to_ary
@@ -83,9 +90,7 @@ module LandingHelper
     list_opts[:per_page] = 30 unless list_opts[:per_page].present?
     topics = list_topics(opts, list_opts)
 
-    if opts[:instance_var]
-      instance_variable_set("@#{opts[:instance_var]}", topics)
-    end
+    instance_variable_set("@#{opts[:instance_var]}", topics) if opts[:instance_var]
 
     if opts[:render_list]
       list_end = topics.count < list_opts[:per_page]
@@ -113,17 +118,15 @@ module LandingHelper
 
   def set_category_user(category_slug, user: current_user)
     if category = Category.find_by(slug: category_slug)
-      category_user = CategoryUser.find_by(
-        category_id: category.id,
-        user_id: user.id
-      )
+      category_user = CategoryUser.find_by(category_id: category.id, user_id: user.id)
 
       if !category_user
-        category_user = CategoryUser.create!(
-          user: user,
-          category_id: category.id,
-          notification_level: CategoryUser.notification_levels[:regular]
-        )
+        category_user =
+          CategoryUser.create!(
+            user: user,
+            category_id: category.id,
+            notification_level: CategoryUser.notification_levels[:regular],
+          )
       end
 
       instance_variable_set("@category_user", category_user)
@@ -134,7 +137,7 @@ module LandingHelper
 
   def get_topic_view(id_or_slug, opts: {}, instance_var: nil, set_page_title: false)
     return nil unless id_or_slug.present?
-    topic = Topic.where('id = ? or slug = ?', id_or_slug.to_i, id_or_slug.to_s)
+    topic = Topic.where("id = ? or slug = ?", id_or_slug.to_i, id_or_slug.to_s)
 
     if topic.exists?
       topic = topic.first

--- a/app/jobs/send_contact_email.rb
+++ b/app/jobs/send_contact_email.rb
@@ -2,15 +2,12 @@
 module Jobs
   class SendContactEmail < ::Jobs::Base
     def execute(args)
-      [
-        :from,
-        :message
-      ].each do |key|
+      %i[from message].each do |key|
         raise Discourse::InvalidParameters.new(key) unless args[key].present?
       end
       message = ContactMailer.contact_email(args[:from], args[:message])
-      message.header['Auto-Submitted'] = nil
-      message.header['X-Auto-Response-Suppress'] = nil
+      message.header["Auto-Submitted"] = nil
+      message.header["X-Auto-Response-Suppress"] = nil
       Email::Sender.new(message, :contact_email).send
     end
   end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -6,11 +6,11 @@ class ContactMailer < ::ActionMailer::Base
     contact_email = SiteSetting.landing_contact_email || SiteSetting.contact_email
     build_email(
       contact_email,
-      template: 'contact_mailer',
-      locale: 'en',
+      template: "contact_mailer",
+      locale: "en",
       from: from,
       message: message,
-      use_from_address_for_reply_to: true
+      use_from_address_for_reply_to: true,
     )
   end
 end

--- a/app/serializers/landing_pages/basic_page.rb
+++ b/app/serializers/landing_pages/basic_page.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 class LandingPages::BasicPageSerializer < ::ApplicationSerializer
-  attributes :id,
-             :name,
-             :path
+  attributes :id, :name, :path
 end

--- a/app/serializers/landing_pages/page.rb
+++ b/app/serializers/landing_pages/page.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 class LandingPages::PageSerializer < ::LandingPages::BasicPageSerializer
-  attributes :parent_id,
-             :category_id,
-             :theme_id,
-             :group_ids,
-             :body,
-             :remote,
-             :menu
+  attributes :parent_id, :category_id, :theme_id, :group_ids, :body, :remote, :menu
 
   def remote
     object.remote.present?

--- a/assets/javascripts/discourse/components/modal/import-pages.hbs
+++ b/assets/javascripts/discourse/components/modal/import-pages.hbs
@@ -5,8 +5,15 @@
 >
   <:body>
     <div class="inputs">
-      <input onchange={{action "uploadFile"}} type="file" id="file-input" accept=".zip,application/zip"><br>
-      <span class="description">{{i18n "admin.landing_pages.import.file_tip"}}</span>
+      <input
+        onchange={{action "uploadFile"}}
+        type="file"
+        id="file-input"
+        accept=".zip,application/zip"
+      /><br />
+      <span class="description">{{i18n
+          "admin.landing_pages.import.file_tip"
+        }}</span>
     </div>
   </:body>
 

--- a/assets/javascripts/discourse/components/modal/import-pages.js.es6
+++ b/assets/javascripts/discourse/components/modal/import-pages.js.es6
@@ -5,7 +5,6 @@ import { action } from "@ember/object";
 import bootbox from "bootbox";
 
 export default Component.extend({
-
   @action
   uploadFile() {
     this.set("pageFile", $("#file-input")[0].files[0]);

--- a/assets/javascripts/discourse/components/page-admin.js.es6
+++ b/assets/javascripts/discourse/components/page-admin.js.es6
@@ -119,7 +119,10 @@ export default Component.extend({
         .then((file) => {
           const link = document.createElement("a");
           link.href = URL.createObjectURL(file);
-          link.setAttribute("download", `discourse-${page.name.toLowerCase()}.zip`);
+          link.setAttribute(
+            "download",
+            `discourse-${page.name.toLowerCase()}.zip`
+          );
           link.click();
         })
         .catch((error) => {

--- a/assets/javascripts/discourse/connectors/topic-category/topic-landing-page-info.hbs
+++ b/assets/javascripts/discourse/connectors/topic-category/topic-landing-page-info.hbs
@@ -1,6 +1,11 @@
 {{#if topic.landing_page_url}}
-  <a href="/{{topic.landing_page_url}}" title="{{i18n 'topic.landing_page.link'}}" class="landing-page-url" target="_blank">
+  <a
+    href="/{{topic.landing_page_url}}"
+    title="{{i18n 'topic.landing_page.link'}}"
+    class="landing-page-url"
+    target="_blank"
+  >
     {{d-icon "file-alt"}}
-    <span>{{i18n 'topic.landing_page.link'}}</span>
+    <span>{{i18n "topic.landing_page.link"}}</span>
   </a>
 {{/if}}

--- a/assets/javascripts/discourse/controllers/admin-plugins-landing-pages.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-landing-pages.js.es6
@@ -139,17 +139,16 @@ export default Controller.extend({
     },
 
     importPages() {
-      this.modal.show(ImportPages)
-        .then((result) => {
-          if (result?.page) {
-            const page = LandingPage.create(result.page);
-            this.setProperties({
-              page: page,
-              currentPage: JSON.parse(JSON.stringify(page)),
-              pages: result.pages,
-            });
-          }
-        });
+      this.modal.show(ImportPages).then((result) => {
+        if (result?.page) {
+          const page = LandingPage.create(result.page);
+          this.setProperties({
+            page,
+            currentPage: JSON.parse(JSON.stringify(page)),
+            pages: result.pages,
+          });
+        }
+      });
     },
 
     updateRemote() {

--- a/assets/javascripts/discourse/templates/admin-plugins-landing-pages.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-landing-pages.hbs
@@ -3,24 +3,27 @@
     {{page-list
       value=page.id
       content=pages
-      onChange=(action 'changePage')
+      onChange=(action "changePage")
       class="page-select"
-      options=(hash
-        none='admin.landing_pages.page.select'
-      )}}
+      options=(hash none="admin.landing_pages.page.select")
+    }}
     {{d-button
       action=(action "createPage")
       label="admin.landing_pages.page.create"
       class="page-create"
-      icon="plus"}}
+      icon="plus"
+    }}
   </div>
-    
+
   <div class="buttons">
     {{#if pullingFromRemote}}
       {{loading-spinner size="small"}}
     {{else}}
       {{#if showCommitsBehind}}
-        {{i18n 'admin.landing_pages.remote.repository.x_commits_behind' count=commitsBehind}}
+        {{i18n
+          "admin.landing_pages.remote.repository.x_commits_behind"
+          count=commitsBehind
+        }}
       {{/if}}
     {{/if}}
 
@@ -29,25 +32,29 @@
       label="admin.landing_pages.remote.pull.label"
       title="admin.landing_pages.remote.pull.description"
       icon="arrow-down"
-      disabled=pullDisabled}}
-    
+      disabled=pullDisabled
+    }}
+
     {{d-button
       action=(action "updateRemote")
       title="admin.landing_pages.remote.repository.description"
       label="admin.landing_pages.remote.repository.label"
-      icon="book"}}
-      
+      icon="book"
+    }}
+
     {{d-button
       action=(action "importPages")
       label="admin.landing_pages.import.button"
       title="admin.landing_pages.import.description"
-      icon="download"}}
+      icon="download"
+    }}
 
     {{d-button
       action=(action "toggleShowGlobal")
       label="admin.landing_pages.global.label"
       title="admin.landing_pages.global.description"
-      icon="globe"}}
+      icon="globe"
+    }}
   </div>
 </div>
 
@@ -64,10 +71,10 @@
   {{/if}}
 
   <div class="message-block">
-    {{d-icon 'question-circle'}}
-        
+    {{d-icon "question-circle"}}
+
     <a href={{documentationUrl}} target="_blank">
-      {{i18n 'admin.landing_pages.documentation'}}
+      {{i18n "admin.landing_pages.documentation"}}
     </a>
   </div>
 </div>
@@ -83,10 +90,10 @@
       themes=themes
       groups=groups
       menus=menus
-      updatePages=(action "updatePages")}}
+      updatePages=(action "updatePages")
+    }}
   {{/if}}
   {{#if showGlobal}}
-    {{global-admin
-      global=global}}
+    {{global-admin global=global}}
   {{/if}}
 {{/if}}

--- a/assets/javascripts/discourse/templates/components/global-admin.hbs
+++ b/assets/javascripts/discourse/templates/components/global-admin.hbs
@@ -1,6 +1,6 @@
 <div class="page-header">
   <div class="page-name">
-    <span>{{i18n 'admin.landing_pages.global.label'}}</span>
+    <span>{{i18n "admin.landing_pages.global.label"}}</span>
   </div>
 
   <div class="buttons">
@@ -8,22 +8,22 @@
       {{d-icon resultIcon}}
     {{/if}}
 
-    {{conditional-loading-spinner
-      condition=updatingGlobal
-      size="small"}}
+    {{conditional-loading-spinner condition=updatingGlobal size="small"}}
 
     {{d-button
       action=(action "destroyGlobal")
       label="admin.landing_pages.destroy"
       disabled=updatingGlobal
-      icon="times"}}
+      icon="times"
+    }}
 
     {{d-button
       action=(action "saveGlobal")
       label="admin.landing_pages.save"
       class="btn-primary"
       disabled=updatingGlobal
-      icon="save"}}
+      icon="save"
+    }}
   </div>
 </div>
 
@@ -33,9 +33,7 @@
       {{i18n "admin.landing_pages.global.scripts.label"}}
     </label>
 
-    {{value-list
-      values=global.scripts
-      inputType="array"}}
+    {{value-list values=global.scripts inputType="array"}}
 
     <div class="control-instructions">
       {{{i18n "admin.landing_pages.global.scripts.description"}}}

--- a/assets/javascripts/discourse/templates/components/page-admin.hbs
+++ b/assets/javascripts/discourse/templates/components/page-admin.hbs
@@ -4,7 +4,7 @@
       {{#if page.name}}
         {{page.name}}
       {{else}}
-        {{i18n 'admin.landing_pages.page.name.label'}}
+        {{i18n "admin.landing_pages.page.name.label"}}
       {{/if}}
     </span>
   </div>
@@ -25,13 +25,15 @@
         label="admin.landing_pages.page.export"
         href=page.exportUrl
         disabled=updatingPage
-        icon="upload"}}
+        icon="upload"
+      }}
 
       {{d-button
         action=(action "destroyPage")
         label="admin.landing_pages.destroy"
         disabled=updatingPage
-        icon="times"}}
+        icon="times"
+      }}
     {{/unless}}
 
     {{d-button
@@ -39,7 +41,8 @@
       label="admin.landing_pages.save"
       class="btn-primary"
       disabled=updatingPage
-      icon="save"}}
+      icon="save"
+    }}
   </div>
 
   <div class="page-url">
@@ -56,10 +59,7 @@
       {{i18n "admin.landing_pages.page.name.label"}}
     </label>
 
-    <Input
-      @value={{page.name}}
-      class="page-name"
-    />
+    <Input @value={{page.name}} class="page-name" />
 
     <div class="control-instructions">
       {{i18n "admin.landing_pages.page.name.instructions"}}
@@ -93,9 +93,8 @@
       content=pages
       onChange=(action "onChangeParent")
       class="page-select page-parent"
-      options=(hash
-        none='admin.landing_pages.page.select'
-      )}}
+      options=(hash none="admin.landing_pages.page.select")
+    }}
 
     <div class="control-instructions">
       {{i18n "admin.landing_pages.page.parent.instructions"}}
@@ -114,9 +113,8 @@
       nameProperty="name"
       onChange=(action (mut page.menu))
       class="menu-select"
-      options=(hash
-        none='admin.landing_pages.page.menu.select'
-      )}}
+      options=(hash none="admin.landing_pages.page.menu.select")
+    }}
 
     <div class="control-instructions">
       {{i18n "admin.landing_pages.page.menu.instructions"}}
@@ -135,9 +133,8 @@
       value=page.theme_id
       onChange=(action (mut page.theme_id))
       class="theme-select"
-      options=(hash
-        none='admin.landing_pages.page.theme.select'
-      )}}
+      options=(hash none="admin.landing_pages.page.theme.select")
+    }}
 
     <div class="control-instructions">
       {{i18n "admin.landing_pages.page.theme.instructions"}}
@@ -154,7 +151,8 @@
       content=groups
       value=page.group_ids
       labelProperty="name"
-      onChange=(action (mut page.group_ids))}}
+      onChange=(action (mut page.group_ids))
+    }}
 
     <div class="control-instructions">
       {{i18n "admin.landing_pages.page.groups.instructions"}}
@@ -171,9 +169,7 @@
       value=page.category_id
       allowUncategorized=false
       onChange=(action (mut page.category_id))
-      options=(hash
-        disabled=hasParent
-      )
+      options=(hash disabled=hasParent)
     }}
 
     <div class="control-instructions">
@@ -191,8 +187,5 @@
     {{i18n "admin.landing_pages.page.body.instructions"}}
   </div>
 
-  <AceEditor
-    @content={{page.body}}
-    @mode="html"
-  />
+  <AceEditor @content={{page.body}} @mode="html" />
 </div>

--- a/assets/javascripts/discourse/templates/modal/update-pages-remote.hbs
+++ b/assets/javascripts/discourse/templates/modal/update-pages-remote.hbs
@@ -1,4 +1,6 @@
-{{#d-modal-body class="update-pages-remote" title="admin.landing_pages.remote.title"}}
+{{#d-modal-body
+  class="update-pages-remote" title="admin.landing_pages.remote.title"
+}}
   <div class="repo">
     <div class="label">{{i18n "admin.landing_pages.remote.url"}}</div>
     {{input value=model.remote.url placeholder=urlPlaceholder}}
@@ -15,7 +17,7 @@
       {{i18n "admin.landing_pages.remote.private"}}
     </label>
   </div>
-  
+
   {{#if showPublicKey}}
     <div class="public-key">
       <div class="label">{{i18n "admin.customize.theme.public_key"}}</div>
@@ -29,14 +31,16 @@
     action=(action "update")
     disabled=updateDisabled
     class="btn btn-primary"
-    label="admin.landing_pages.remote.update"}}
-  
+    label="admin.landing_pages.remote.update"
+  }}
+
   {{d-button
     action="test"
     class="btn btn-test"
     disabled=testDisabled
-    label="admin.landing_pages.remote.test"}}
-    
+    label="admin.landing_pages.remote.test"
+  }}
+
   {{#if testing}}
     {{loading-spinner size="small"}}
   {{else}}
@@ -44,6 +48,6 @@
       {{d-icon testIcon}}
     {{/if}}
   {{/if}}
-  
+
   {{d-modal-cancel close=(route-action "closeModal")}}
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 LandingPages::Engine.routes.draw do
   resources :page, constraints: AdminConstraint.new do
-    member do
-      get "export" => "page#export"
-    end
-    collection do
-      post "upload" => "page#upload"
-    end
+    member { get "export" => "page#export" }
+    collection { post "upload" => "page#upload" }
   end
 
   resource :remote, constraints: AdminConstraint.new do
@@ -26,7 +22,7 @@ end
 
 Discourse::Application.routes.prepend do
   mount ::LandingPages::Engine, at: "landing"
-  get "/admin/plugins/landing-pages" => "admin/plugins#index", constraints: AdminConstraint.new
-  get "/:path" => "landing_pages/landing#show", constraints: LandingPageConstraint.new
-  get "/:path/:param" => "landing_pages/landing#show", constraints: LandingPageConstraint.new
+  get "/admin/plugins/landing-pages" => "admin/plugins#index", :constraints => AdminConstraint.new
+  get "/:path" => "landing_pages/landing#show", :constraints => LandingPageConstraint.new
+  get "/:path/:param" => "landing_pages/landing#show", :constraints => LandingPageConstraint.new
 end

--- a/extensions/content_security_policy.rb
+++ b/extensions/content_security_policy.rb
@@ -4,7 +4,7 @@ module ContentSecurityPolicyLandingPagesExtension
     super.tap do |obj|
       obj[:script_src] ||= []
       obj[:script_src] = [*obj[:script_src]].concat(
-        LandingPages::Global.scripts
+        LandingPages::Global.scripts,
       ) if LandingPages::Global.scripts.present?
     end
   end

--- a/extensions/upload_validator.rb
+++ b/extensions/upload_validator.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 module UploadValidatorLandingPagesExtension
   private def authorized_extensions(upload)
-    if upload.for_landing_page
-      return extensions_to_set(SiteSetting.landing_authorized_extensions)
-    end
+    return extensions_to_set(SiteSetting.landing_authorized_extensions) if upload.for_landing_page
     super
   end
 
   private def authorizes_all_extensions?(upload)
-    if upload.for_landing_page &&
-        SiteSetting.landing_authorized_extensions.include?("*")
+    if upload.for_landing_page && SiteSetting.landing_authorized_extensions.include?("*")
       return true
     end
     super

--- a/extensions/user_email_job.rb
+++ b/extensions/user_email_job.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 module UserEmailJobLandingPagesExtension
   def always_email_regular?(user, type)
-    super || begin
-      return false unless @skip_context[:post_id] && post = Post.find_by(id: @skip_context[:post_id])
-      post.topic&.category&.landing_page_id.present?
-    end
+    super ||
+      begin
+        unless @skip_context[:post_id] && post = Post.find_by(id: @skip_context[:post_id])
+          return false
+        end
+        post.topic&.category&.landing_page_id.present?
+      end
   end
 end

--- a/extensions/user_notifications.rb
+++ b/extensions/user_notifications.rb
@@ -9,10 +9,7 @@ module UserNotificationsLandingPagesExtension
   end
 
   def landing_email_notification_type?
-    %w(
-     watching
-     watching_first_post
-    ).include?(@notification_type)
+    %w[watching watching_first_post].include?(@notification_type)
   end
 
   protected def send_notification_email(opts)
@@ -31,13 +28,8 @@ module UserNotificationsLandingPagesExtension
   def landing_email_html(opts)
     return landing_page.email if landing_page.email.present?
 
-    unstyled = LandingEmailRenderer.render(
-      template: 'email/landing',
-      format: :html,
-      locals: {
-        post: @post
-      }
-    )
+    unstyled =
+      LandingEmailRenderer.render(template: "email/landing", format: :html, locals: { post: @post })
     style = Email::Styles.new(unstyled, opts)
 
     style.format_basic

--- a/lib/landing_email_renderer.rb
+++ b/lib/landing_email_renderer.rb
@@ -8,9 +8,10 @@ class LandingEmailRenderer < ActionView::Base
 
   def self.render(*args)
     LOCK.synchronize do
-      @instance ||= LandingEmailRenderer.with_empty_template_cache.with_view_paths(
-        Rails.configuration.paths["plugins/discourse-landing-pages/app/views/discourse"]
-      )
+      @instance ||=
+        LandingEmailRenderer.with_empty_template_cache.with_view_paths(
+          Rails.configuration.paths["plugins/discourse-landing-pages/app/views/discourse"],
+        )
       @instance.render(*args)
     end
   end

--- a/lib/landing_page_constraint.rb
+++ b/lib/landing_page_constraint.rb
@@ -2,6 +2,6 @@
 
 class LandingPageConstraint
   def matches?(request)
-    LandingPages::Page.exists?(request.path_parameters[:path], attr: 'path')
+    LandingPages::Page.exists?(request.path_parameters[:path], attr: "path")
   end
 end

--- a/lib/landing_pages/asset.rb
+++ b/lib/landing_pages/asset.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'net/http'
-require 'addressable/uri'
+require "net/http"
+require "addressable/uri"
 
 class LandingPages::Asset
   include HasErrors
@@ -9,17 +9,16 @@ class LandingPages::Asset
 
   KEY ||= "asset"
 
-  attr_reader :id,
-              :upload
+  attr_reader :id, :upload
 
   attr_accessor :file
 
   def self.required_attrs
-    %w(name file).freeze
+    %w[name file].freeze
   end
 
   def self.writable_attrs
-    %w(name upload_id).freeze
+    %w[name upload_id].freeze
   end
 
   def initialize(asset_id, data = {})
@@ -35,7 +34,7 @@ class LandingPages::Asset
       value = data[attr]
 
       if value.present?
-        value = value.parameterize.underscore if attr === 'name'
+        value = value.parameterize.underscore if attr === "name"
         send("#{attr}=", value)
       end
     end
@@ -47,7 +46,7 @@ class LandingPages::Asset
         @upload = upload
       else
         @upload_id = nil
-        add_error(I18n.t("landing_pages.error.attr_required", attr: 'upload_id'))
+        add_error(I18n.t("landing_pages.error.attr_required", attr: "upload_id"))
       end
     end
   end
@@ -72,9 +71,7 @@ class LandingPages::Asset
 
   def validate
     self.class.required_attrs.each do |attr|
-      if send(attr).blank?
-        add_error(I18n.t("landing_pages.error.attr_required", attr: attr))
-      end
+      add_error(I18n.t("landing_pages.error.attr_required", attr: attr)) if send(attr).blank?
     end
   end
 
@@ -113,13 +110,14 @@ class LandingPages::Asset
     ## Fallback attempt
     if upload.blank?
       user = Discourse.system_user
-      upload = UploadCreator.new(file, File.basename(file.path), for_landing_page: true).create_for(user.id)
+      upload =
+        UploadCreator.new(file, File.basename(file.path), for_landing_page: true).create_for(
+          user.id,
+        )
       @upload_id = upload.id
     end
 
-    if upload.blank?
-      add_error(I18n.t("landing_pages.error.attr_required", attr: 'upload_id'))
-    end
+    add_error(I18n.t("landing_pages.error.attr_required", attr: "upload_id")) if upload.blank?
   end
 
   def self.find(asset_id)
@@ -161,9 +159,7 @@ class LandingPages::Asset
   end
 
   def self.all
-    PluginStoreRow.where(list_query).to_a.map do |row|
-      new(row['key'], JSON.parse(row['value']))
-    end
+    PluginStoreRow.where(list_query).to_a.map { |row| new(row["key"], JSON.parse(row["value"])) }
   end
 
   def self.query(attr, value)

--- a/lib/landing_pages/engine.rb
+++ b/lib/landing_pages/engine.rb
@@ -2,7 +2,7 @@
 
 module ::LandingPages
   class Engine < ::Rails::Engine
-    engine_name 'landing_pages'
+    engine_name "landing_pages"
     isolate_namespace LandingPages
   end
 
@@ -11,8 +11,6 @@ module ::LandingPages
   CATEGORY_IDS_KEY ||= "category_ids"
 
   def self.paths
-    LandingPages::Cache.wrap(PATHS_KEY) do
-      LandingPages::Page.all.map(&:path)
-    end
+    LandingPages::Cache.wrap(PATHS_KEY) { LandingPages::Page.all.map(&:path) }
   end
 end

--- a/lib/landing_pages/global.rb
+++ b/lib/landing_pages/global.rb
@@ -7,7 +7,7 @@ class LandingPages::Global
   KEY ||= "global"
 
   def self.writable_attrs
-    %w(scripts footer header).freeze
+    %w[scripts footer header].freeze
   end
 
   def initialize(data = {})

--- a/lib/landing_pages/import_export/git_importer.rb
+++ b/lib/landing_pages/import_export/git_importer.rb
@@ -3,10 +3,10 @@
 class LandingPages::GitImporter < ThemeStore::GitImporter
   attr_reader :temp_folder
 
-  def initialize(url, private_key: nil, branch: nil, temp_folder: '/')
+  def initialize(url, private_key: nil, branch: nil, temp_folder: "/")
     @url = url
     if @url.present? && @url.start_with?("https://github.com") && !@url.end_with?(".git")
-      @url = @url.gsub(/\/$/, '')
+      @url = @url.gsub(%r{/$}, "")
       @url += ".git"
     end
     @temp_folder = temp_folder
@@ -18,10 +18,14 @@ class LandingPages::GitImporter < ThemeStore::GitImporter
     return false unless @url
 
     begin
-      response = Discourse::Utils.execute_command(
-        { "GIT_SSH_COMMAND" => "ssh -i #{ssh_folder}/id_rsa -o StrictHostKeyChecking=no" },
-        "git", "ls-remote", url, "--exit-code"
-      )
+      response =
+        Discourse::Utils.execute_command(
+          { "GIT_SSH_COMMAND" => "ssh -i #{ssh_folder}/id_rsa -o StrictHostKeyChecking=no" },
+          "git",
+          "ls-remote",
+          url,
+          "--exit-code",
+        )
     rescue RuntimeError => err
       response = 2
     end
@@ -34,7 +38,7 @@ class LandingPages::GitImporter < ThemeStore::GitImporter
   def ssh_folder
     path = "#{Pathname.new(Dir.tmpdir).realpath}/landing_page_ssh_#{SecureRandom.hex}"
     FileUtils.mkdir_p path
-    File.write("#{path}/id_rsa", @private_key || '')
+    File.write("#{path}/id_rsa", @private_key || "")
     FileUtils.chmod(0600, "#{path}/id_rsa")
     path
   end

--- a/lib/landing_pages/import_export/zip_exporter.rb
+++ b/lib/landing_pages/import_export/zip_exporter.rb
@@ -4,7 +4,7 @@ class LandingPages::ZipExporter < ThemeStore::ZipExporter
   def initialize(page)
     @page = page
     @temp_folder = "#{Pathname.new(Dir.tmpdir).realpath}/landing_page_#{SecureRandom.hex}"
-    @export_name = @page.name.downcase.gsub(/[^0-9a-z.\-]/, '-')
+    @export_name = @page.name.downcase.gsub(/[^0-9a-z.\-]/, "-")
     @export_name = "discourse-#{@export_name}" unless @export_name.starts_with?("discourse")
   end
 
@@ -38,9 +38,7 @@ class LandingPages::ZipExporter < ThemeStore::ZipExporter
   def filename(attr)
     name = attr
 
-    ext = {
-      body: '.html.erb'
-    }[attr.to_sym]
+    ext = { body: ".html.erb" }[attr.to_sym]
 
     name += ext if ext
     name

--- a/lib/landing_pages/import_export/zip_importer.rb
+++ b/lib/landing_pages/import_export/zip_importer.rb
@@ -3,7 +3,7 @@
 class LandingPages::ZipImporter < ThemeStore::ZipImporter
   attr_reader :temp_folder
 
-  def initialize(filename, original_filename, temp_folder: '/')
+  def initialize(filename, original_filename, temp_folder: "/")
     @temp_folder = temp_folder
     @filename = filename
     @original_filename = original_filename

--- a/lib/landing_pages/menu.rb
+++ b/lib/landing_pages/menu.rb
@@ -8,11 +8,10 @@ class LandingPages::Menu
 
   attr_reader :id
 
-  attr_accessor :name,
-                :items
+  attr_accessor :name, :items
 
   def self.writable_attrs
-    %w(name items).freeze
+    %w[name items].freeze
   end
 
   def initialize(menu_id, data = {})
@@ -28,8 +27,8 @@ class LandingPages::Menu
       value = data[attr]
 
       if value.present?
-        value = value.parameterize.underscore if attr === 'name'
-        value = value if attr === 'items'
+        value = value.parameterize.underscore if attr === "name"
+        value = value if attr === "items"
 
         send("#{attr}=", value)
       end
@@ -54,10 +53,8 @@ class LandingPages::Menu
   end
 
   def validate
-    %w(name items).each do |attr|
-      if send(attr).blank?
-        add_error(I18n.t("landing_pages.error.attr_required", attr: attr))
-      end
+    %w[name items].each do |attr|
+      add_error(I18n.t("landing_pages.error.attr_required", attr: attr)) if send(attr).blank?
     end
   end
 
@@ -105,9 +102,10 @@ class LandingPages::Menu
   end
 
   def self.all
-    PluginStoreRow.where(menu_list_query).to_a.map do |row|
-      new(row['key'], JSON.parse(row['value']))
-    end
+    PluginStoreRow
+      .where(menu_list_query)
+      .to_a
+      .map { |row| new(row["key"], JSON.parse(row["value"])) }
   end
 
   def self.menu_query(attr, value)

--- a/lib/landing_pages/remote.rb
+++ b/lib/landing_pages/remote.rb
@@ -4,10 +4,10 @@ class LandingPages::Remote
   include ActiveModel::Serialization
   include HasErrors
 
-  KEY ||= 'remote'
+  KEY ||= "remote"
 
   def self.writable_attrs
-    %w(url public_key private_key branch commit).freeze
+    %w[url public_key private_key branch commit].freeze
   end
 
   def initialize(opts)
@@ -37,33 +37,27 @@ class LandingPages::Remote
   end
 
   def validate
-    unless valid_url?
-      add_error(I18n.t("landing_pages.error.remote_invalid_url"))
-    end
+    add_error(I18n.t("landing_pages.error.remote_invalid_url")) unless valid_url?
   end
 
   def valid_url?
-    url =~ URI::regexp
+    url =~ URI.regexp
   end
 
   def connected
     return false unless valid_url?
 
-    LandingPages::GitImporter.new(url,
-      private_key: private_key,
-      branch: branch
-    ).connected
+    LandingPages::GitImporter.new(url, private_key: private_key, branch: branch).connected
   end
 
   def commits_behind
-    @commits_behind ||= begin
-      importer = LandingPages::Importer.new(:git)
-      importer.import!
+    @commits_behind ||=
+      begin
+        importer = LandingPages::Importer.new(:git)
+        importer.import!
 
-      if importer.report[:errors].blank?
-        importer.handler.commits_since(commit).last.to_i
+        importer.handler.commits_since(commit).last.to_i if importer.report[:errors].blank?
       end
-    end
   end
 
   def reset
@@ -97,9 +91,9 @@ class LandingPages::Remote
 
       if remote_pages.exists?
         remote_pages.each do |record|
-          value = JSON.parse(record['value'])
+          value = JSON.parse(record["value"])
           value.delete("remote")
-          record['value'] = value.to_json
+          record["value"] = value.to_json
           record.save
         end
       end

--- a/lib/landing_pages/updater.rb
+++ b/lib/landing_pages/updater.rb
@@ -8,14 +8,7 @@ class LandingPages::Updater
   def initialize(type, handler)
     @type = type
     @handler = handler
-    @updated = {
-      scripts: [],
-      footer: false,
-      header: false,
-      menus: [],
-      assets: [],
-      pages: []
-    }
+    @updated = { scripts: [], footer: false, header: false, menus: [], assets: [], pages: [] }
   end
 
   def update_page(data)
@@ -38,11 +31,7 @@ class LandingPages::Updater
       page.save
     end
 
-    if page.errors.any?
-      add_errors_from(page)
-    else
-      @updated[:pages].push(page.name)
-    end
+    page.errors.any? ? add_errors_from(page) : @updated[:pages].push(page.name)
   end
 
   def update_assets(data)
@@ -60,11 +49,7 @@ class LandingPages::Updater
         asset.save
       end
 
-      if asset.errors.any?
-        add_errors_from(asset)
-      else
-        @updated[:assets].push(asset.name)
-      end
+      asset.errors.any? ? add_errors_from(asset) : @updated[:assets].push(asset.name)
     end
   end
 
@@ -85,10 +70,7 @@ class LandingPages::Updater
 
     if data[:menus].present?
       data[:menus].each do |menu_data|
-        menu_data = {
-          name: menu_data["name"],
-          items: menu_data["items"]
-        }
+        menu_data = { name: menu_data["name"], items: menu_data["items"] }
         menu = LandingPages::Menu.find_by("name", menu_data[:name])
 
         if menu.blank?
@@ -98,15 +80,11 @@ class LandingPages::Updater
           menu.save
         end
 
-        if menu.errors.any?
-          add_errors_from(menu)
-        else
-          updated_menus.push(menu.name)
-        end
+        menu.errors.any? ? add_errors_from(menu) : updated_menus.push(menu.name)
       end
     end
 
-    unless errors.any?
+    if errors.none?
       @updated[:scripts] = updated_scripts
       @updated[:menus] = updated_menus
       @updated[:header] = updated_header

--- a/plugin.rb
+++ b/plugin.rb
@@ -18,9 +18,7 @@ end
 
 add_admin_route "admin.landing_pages.title", "landing-pages"
 
-extend_content_security_policy(
-  script_src: ['https://ajax.googleapis.com']
-)
+extend_content_security_policy(script_src: ["https://ajax.googleapis.com"])
 
 after_initialize do
   %w[
@@ -58,9 +56,7 @@ after_initialize do
     ../extensions/upload_creator.rb
     ../extensions/user_notifications.rb
     ../extensions/user_email_job.rb
-  ].each do |path|
-    load File.expand_path(path, __FILE__)
-  end
+  ].each { |path| load File.expand_path(path, __FILE__) }
 
   add_to_class(:site, :landing_paths) { ::LandingPages.paths }
   add_to_serializer(:site, :landing_paths) { object.landing_paths }
@@ -74,9 +70,13 @@ after_initialize do
 
   TopicQuery.add_custom_filter(:definitions_only) do |topics, query|
     if query.options[:category_id] && query.options[:definitions_only]
-      topics = topics.where("
+      topics =
+        topics.where(
+          "
         topics.id in (SELECT topic_id FROM categories WHERE categories.id in (?))
-      ", Category.subcategory_ids(query.options[:category_id]))
+      ",
+          Category.subcategory_ids(query.options[:category_id]),
+        )
     end
 
     topics
@@ -91,18 +91,18 @@ after_initialize do
   end
 
   full_path = "#{Rails.root}/plugins/discourse-landing-pages/assets/stylesheets/page/page.scss"
-  Stylesheet::Importer.plugin_assets['landing_page'] = Set[full_path]
+  Stylesheet::Importer.plugin_assets["landing_page"] = Set[full_path]
 
   add_to_class(:category, :landing_page_id) do
-    (LandingPages::Cache.new(LandingPages::CATEGORY_IDS_KEY).read || {})
-      .transform_keys(&:to_i)[self.id]
+    (LandingPages::Cache.new(LandingPages::CATEGORY_IDS_KEY).read || {}).transform_keys(&:to_i)[
+      self.id
+    ]
   end
 
   add_to_class(:topic, :landing_page_url) do
     return nil if !category
 
-    if category.landing_page_id &&
-        page = LandingPages::Page.find(category.landing_page_id)
+    if category.landing_page_id && page = LandingPages::Page.find(category.landing_page_id)
       page.path + "/#{slug}"
     else
       nil
@@ -112,6 +112,6 @@ after_initialize do
   add_to_serializer(
     :topic_view,
     :landing_page_url,
-    include_condition: -> { object.topic.landing_page_url.present? }
+    include_condition: -> { object.topic.landing_page_url.present? },
   ) { object.topic.landing_page_url }
 end

--- a/spec/components/asset_spec.rb
+++ b/spec/components/asset_spec.rb
@@ -1,31 +1,27 @@
 # frozen_string_literal: true
-require_relative '../plugin_helper'
+require_relative "../plugin_helper"
 
 describe LandingPages::Asset do
-  let(:asset_1_path) {
-    "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/asset_1.json"
-  }
+  let(:asset_1_path) { "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/asset_1.json" }
 
-  let(:asset_2_path) {
-    "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/asset_2.json"
-  }
+  let(:asset_2_path) { "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/asset_2.json" }
 
   it "creates an asset" do
     asset_file = File.new(asset_1_path)
-    asset = LandingPages::Asset.create(name: 'animation', file: asset_file)
+    asset = LandingPages::Asset.create(name: "animation", file: asset_file)
     expect(asset.name).to eq("animation")
   end
 
   it "does not create an asset if required attributes are missing" do
-    asset = LandingPages::Asset.create(name: 'animation', file: nil)
+    asset = LandingPages::Asset.create(name: "animation", file: nil)
     expect(asset.errors.full_messages.first).to eq(
-      I18n.t("landing_pages.error.attr_required", attr: 'file')
+      I18n.t("landing_pages.error.attr_required", attr: "file"),
     )
   end
 
   it "creates an upload for an asset" do
     asset_file = File.new(asset_1_path)
-    asset = LandingPages::Asset.create(name: 'animation', file: asset_file)
+    asset = LandingPages::Asset.create(name: "animation", file: asset_file)
 
     expect(asset.upload_id.present?).to eq(true)
 
@@ -37,7 +33,7 @@ describe LandingPages::Asset do
 
   it "destroys an asset" do
     asset_file = File.new(asset_1_path)
-    asset = LandingPages::Asset.create(name: 'animation', file: asset_file)
+    asset = LandingPages::Asset.create(name: "animation", file: asset_file)
     LandingPages::Asset.destroy(asset.id)
 
     expect(LandingPages::Asset.find(asset.id)).to eq(nil)
@@ -45,16 +41,16 @@ describe LandingPages::Asset do
 
   it "lists assets" do
     asset_file = File.new(asset_1_path)
-    asset = LandingPages::Asset.create(name: 'animation', file: asset_file)
+    asset = LandingPages::Asset.create(name: "animation", file: asset_file)
     second_asset_file = File.new(asset_2_path)
-    seond_asset = LandingPages::Asset.create(name: 'second_animation', file: second_asset_file)
+    seond_asset = LandingPages::Asset.create(name: "second_animation", file: second_asset_file)
 
     expect(LandingPages::Asset.all.length).to eq(2)
   end
 
   it "updates the asset upload if the asset file changes" do
     asset_file = File.new(asset_1_path)
-    asset = LandingPages::Asset.create(name: 'animation', file: asset_file)
+    asset = LandingPages::Asset.create(name: "animation", file: asset_file)
 
     upload = Upload.find(asset.upload_id)
     expect(upload.filesize).to eq(File.size(asset_1_path))

--- a/spec/components/global_spec.rb
+++ b/spec/components/global_spec.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
-require_relative '../plugin_helper'
+require_relative "../plugin_helper"
 
 describe LandingPages::Global do
-  let(:raw_global) {
-    JSON.parse(File.open(
-      "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/pages.json"
-    ).read)
-  }
+  let(:raw_global) do
+    JSON.parse(
+      File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/pages.json").read,
+    )
+  end
 
   it "saves a global record" do
     global = LandingPages::Global.new(raw_global)
     global.save
 
-    expect(global.scripts).to eq(raw_global['scripts'])
-    expect(global.footer).to eq(raw_global['footer'])
-    expect(global.header).to eq(raw_global['header'])
+    expect(global.scripts).to eq(raw_global["scripts"])
+    expect(global.footer).to eq(raw_global["footer"])
+    expect(global.header).to eq(raw_global["header"])
   end
 
   it "destroys a global record" do

--- a/spec/components/importer_spec.rb
+++ b/spec/components/importer_spec.rb
@@ -1,27 +1,25 @@
 # frozen_string_literal: true
-require_relative '../plugin_helper'
+require_relative "../plugin_helper"
 
 describe LandingPages::Importer do
-  let(:raw_global) {
-    JSON.parse(File.open(
-      "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/pages.json"
-    ).read)
-  }
-  let(:raw_assets) {
-    JSON.parse(File.open(
-      "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/assets.json"
-    ).read)
-  }
-  let(:raw_page) {
-    JSON.parse(File.open(
-      "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/page.json"
-    ).read)
-  }
-  let(:raw_body) {
-    File.open(
-      "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/body.html.erb"
-    ).read
-  }
+  let(:raw_global) do
+    JSON.parse(
+      File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/pages.json").read,
+    )
+  end
+  let(:raw_assets) do
+    JSON.parse(
+      File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/assets.json").read,
+    )
+  end
+  let(:raw_page) do
+    JSON.parse(
+      File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/page.json").read,
+    )
+  end
+  let(:raw_body) do
+    File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/body.html.erb").read
+  end
 
   before do
     temp_folder_path = "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures"
@@ -30,7 +28,10 @@ describe LandingPages::Importer do
     LandingPages::Importer.any_instance.stubs(:temp_folder).returns(temp_folder)
     LandingPages::GitImporter.any_instance.stubs(:import!).returns(true)
     LandingPages::GitImporter.any_instance.stubs(:connected).returns(true)
-    LandingPages::GitImporter.any_instance.stubs(:version).returns("69acc9abf1026c038ae99a0c91f4e15afa454333")
+    LandingPages::GitImporter
+      .any_instance
+      .stubs(:version)
+      .returns("69acc9abf1026c038ae99a0c91f4e15afa454333")
     LandingPages::GitImporter.any_instance.stubs(:cleanup!).returns(true)
   end
 
@@ -39,9 +40,9 @@ describe LandingPages::Importer do
     importer.perform!
 
     global = LandingPages::Global.find
-    expect(global.scripts).to eq(raw_global['scripts'])
-    expect(global.footer).to eq(raw_global['footer'])
-    expect(global.header).to eq(raw_global['header'])
+    expect(global.scripts).to eq(raw_global["scripts"])
+    expect(global.footer).to eq(raw_global["footer"])
+    expect(global.header).to eq(raw_global["header"])
 
     assets = LandingPages::Asset.all
     expect(assets.length).to eq(2)
@@ -61,11 +62,11 @@ describe LandingPages::Importer do
           footer: true,
           header: true,
           menus: ["my_menu"],
-          assets: ["asset_1", "asset_2"],
-          pages: ["My Page", "My Second Page"]
+          assets: %w[asset_1 asset_2],
+          pages: ["My Page", "My Second Page"],
         },
-        errors: []
-      }
+        errors: [],
+      },
     )
   end
 end

--- a/spec/components/menu_spec.rb
+++ b/spec/components/menu_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require_relative '../plugin_helper'
+require_relative "../plugin_helper"
 
 describe LandingPages::Menu do
-  let(:raw_global) {
-    JSON.parse(File.open(
-      "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/pages.json"
-    ).read)
-  }
+  let(:raw_global) do
+    JSON.parse(
+      File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/pages.json").read,
+    )
+  end
 
   it "creates a menu" do
     raw_menu = raw_global["menus"].first
@@ -18,11 +18,11 @@ describe LandingPages::Menu do
 
   it "does not create a menu if required attributes are missing" do
     raw_menu = raw_global["menus"].first
-    raw_menu['name'] = nil
+    raw_menu["name"] = nil
     menu = LandingPages::Menu.create(raw_menu)
 
     expect(menu.errors.full_messages.first).to eq(
-      I18n.t("landing_pages.error.attr_required", attr: 'name')
+      I18n.t("landing_pages.error.attr_required", attr: "name"),
     )
   end
 

--- a/spec/components/page_spec.rb
+++ b/spec/components/page_spec.rb
@@ -1,23 +1,19 @@
 # frozen_string_literal: true
-require_relative '../plugin_helper'
+require_relative "../plugin_helper"
 
 describe LandingPages::Page do
-  fab!(:theme) { Fabricate(:theme, name: 'Landing Theme') }
-  fab!(:group) { Fabricate(:group, name: 'page_group') }
+  fab!(:theme) { Fabricate(:theme, name: "Landing Theme") }
+  fab!(:group) { Fabricate(:group, name: "page_group") }
 
-  let(:raw_page) {
+  let(:raw_page) do
     JSON.parse(
-      File.open(
-        "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/page.json"
-      ).read
+      File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/page.json").read,
     )
-  }
+  end
 
-  let(:raw_body) {
-    File.open(
-      "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/body.html.erb"
-    ).read
-  }
+  let(:raw_body) do
+    File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/body.html.erb").read
+  end
 
   before do
     @params = raw_page
@@ -26,7 +22,7 @@ describe LandingPages::Page do
 
   it "creates a page" do
     LandingPages::Page.create(@params)
-    page = LandingPages::Page.find_by('name', raw_page['name'])
+    page = LandingPages::Page.find_by("name", raw_page["name"])
 
     expect(page.name).to eq("My Page")
     expect(page.path).to eq("my-page")
@@ -39,7 +35,7 @@ describe LandingPages::Page do
     page = LandingPages::Page.create(@params)
 
     expect(page.errors.full_messages.first).to eq(
-      I18n.t("landing_pages.error.attr_required", attr: required_attr)
+      I18n.t("landing_pages.error.attr_required", attr: required_attr),
     )
   end
 
@@ -48,7 +44,7 @@ describe LandingPages::Page do
     @params[:groups] = [group.name]
     LandingPages::Page.find_discourse_objects(@params)
     LandingPages::Page.create(@params)
-    page = LandingPages::Page.find_by('name', raw_page['name'])
+    page = LandingPages::Page.find_by("name", raw_page["name"])
 
     expect(page.theme_id).to eq(theme.id)
     expect(page.group_ids).to eq([group.id])
@@ -60,19 +56,19 @@ describe LandingPages::Page do
     @params[:theme] = theme.name
     LandingPages::Page.find_discourse_objects(@params)
     LandingPages::Page.create(@params)
-    page = LandingPages::Page.find_by('name', raw_page['name'])
+    page = LandingPages::Page.find_by("name", raw_page["name"])
 
     expect(page.theme_id).to eq(nil)
   end
 
   it "creates a page with pages attributes" do
-    @params[:remote] = 'https://github.com/paviliondev/pages-repo.git'
+    @params[:remote] = "https://github.com/paviliondev/pages-repo.git"
     @params[:assets] = ["animation"]
 
     LandingPages::Page.create(@params)
-    page = LandingPages::Page.find_by('name', raw_page['name'])
+    page = LandingPages::Page.find_by("name", raw_page["name"])
 
-    expect(page.remote).to eq('https://github.com/paviliondev/pages-repo.git')
+    expect(page.remote).to eq("https://github.com/paviliondev/pages-repo.git")
     expect(page.assets).to eq(["animation"])
   end
 
@@ -81,7 +77,7 @@ describe LandingPages::Page do
     page = LandingPages::Page.create(@params)
 
     expect(page.errors.full_messages.first).to eq(
-      I18n.t("landing_pages.error.attr_exists", attr: 'path')
+      I18n.t("landing_pages.error.attr_exists", attr: "path"),
     )
   end
 
@@ -105,13 +101,13 @@ describe LandingPages::Page do
     LandingPages::Page.create(@params)
 
     second_page_params = @params.dup
-    second_page_params['name'] = 'My second page'
-    second_page_params['path'] = 'my-second-page'
+    second_page_params["name"] = "My second page"
+    second_page_params["path"] = "my-second-page"
     LandingPages::Page.create(second_page_params)
 
     all_pages = LandingPages::Page.all
     expect(all_pages.length).to eq(2)
-    expect(all_pages.select { |p| p.path == 'my-page' }.length).to eq(1)
-    expect(all_pages.select { |p| p.path == 'my-second-page' }.length).to eq(1)
+    expect(all_pages.select { |p| p.path == "my-page" }.length).to eq(1)
+    expect(all_pages.select { |p| p.path == "my-second-page" }.length).to eq(1)
   end
 end

--- a/spec/components/remote_spec.rb
+++ b/spec/components/remote_spec.rb
@@ -1,24 +1,22 @@
 # frozen_string_literal: true
-require_relative '../plugin_helper'
+require_relative "../plugin_helper"
 
 describe LandingPages::Remote do
-  let(:raw_remote) {
-    JSON.parse(File.open(
-      "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/remote.json"
-    ).read)
-  }
+  let(:raw_remote) do
+    JSON.parse(
+      File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/remote.json").read,
+    )
+  end
 
-  let(:raw_page) {
-    JSON.parse(File.open(
-      "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/page.json"
-    ).read)
-  }
+  let(:raw_page) do
+    JSON.parse(
+      File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/page.json").read,
+    )
+  end
 
-  let(:raw_body) {
-    File.open(
-      "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/body.html.erb"
-    ).read
-  }
+  let(:raw_body) do
+    File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/body.html.erb").read
+  end
 
   before do
     commit_hash = "69acc9abf1026c038ae99a0c91f4e15afa454333"
@@ -26,13 +24,16 @@ describe LandingPages::Remote do
 
     LandingPages::GitImporter.any_instance.stubs(:import!).returns(true)
     LandingPages::GitImporter.any_instance.stubs(:connected).returns(true)
-    LandingPages::GitImporter.any_instance.stubs(:commits_since).returns([commit_hash, commits_behind])
+    LandingPages::GitImporter
+      .any_instance
+      .stubs(:commits_since)
+      .returns([commit_hash, commits_behind])
 
     @remote = LandingPages::Remote.update(raw_remote)
   end
 
   it "updates the remote" do
-    expect(LandingPages::Remote.get.url).to eq(raw_remote['url'])
+    expect(LandingPages::Remote.get.url).to eq(raw_remote["url"])
   end
 
   it "destroys the remote" do
@@ -41,16 +42,16 @@ describe LandingPages::Remote do
   end
 
   it "removes remote from pages imported from a destroyed remote" do
-    raw_page['remote'] = 'https://github.com/paviliondev/pages-repo.git'
-    raw_page['body'] = raw_body
+    raw_page["remote"] = "https://github.com/paviliondev/pages-repo.git"
+    raw_page["body"] = raw_body
 
     page = LandingPages::Page.create(raw_page)
-    expect(page.remote).to eq('https://github.com/paviliondev/pages-repo.git')
+    expect(page.remote).to eq("https://github.com/paviliondev/pages-repo.git")
 
     LandingPages::Remote.destroy
     expect(LandingPages::Remote.exists?).to eq(false)
 
-    page = LandingPages::Page.find_by('name', raw_page['name'])
+    page = LandingPages::Page.find_by("name", raw_page["name"])
     expect(page.remote).to eq(nil)
   end
 

--- a/spec/components/updater_spec.rb
+++ b/spec/components/updater_spec.rb
@@ -1,51 +1,43 @@
 # frozen_string_literal: true
-require_relative '../plugin_helper'
+require_relative "../plugin_helper"
 
 describe LandingPages::Updater do
-  let(:raw_remote) {
+  let(:raw_remote) do
     JSON.parse(
-      File.open(
-        "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/remote.json"
-      ).read
+      File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/remote.json").read,
     ).with_indifferent_access
-  }
-  let(:raw_global) {
+  end
+  let(:raw_global) do
     JSON.parse(
-      File.open(
-        "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/pages.json"
-      ).read
+      File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/pages.json").read,
     ).with_indifferent_access
-  }
-  let(:raw_assets) {
+  end
+  let(:raw_assets) do
     JSON.parse(
-      File.open(
-        "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/assets.json"
-      ).read
+      File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/assets.json").read,
     ).with_indifferent_access
-  }
-  let(:raw_page) {
+  end
+  let(:raw_page) do
     JSON.parse(
-      File.open(
-        "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/page.json"
-      ).read
+      File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/page.json").read,
     ).with_indifferent_access
-  }
-  let(:raw_body) {
-    File.open(
-      "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/body.html.erb"
-    ).read
-  }
+  end
+  let(:raw_body) do
+    File.open("#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures/body.html.erb").read
+  end
 
   before do
     LandingPages::Remote.update(raw_remote)
     remote = LandingPages::Remote.get
     temp_folder_path = "#{Rails.root}/plugins/discourse-landing-pages/spec/fixtures"
     temp_folder = Pathname.new(temp_folder_path).realpath.to_s
-    handler = LandingPages::GitImporter.new(remote.url,
-      private_key: remote.private_key,
-      branch: remote.branch,
-      temp_folder: temp_folder
-    )
+    handler =
+      LandingPages::GitImporter.new(
+        remote.url,
+        private_key: remote.private_key,
+        branch: remote.branch,
+        temp_folder: temp_folder,
+      )
     @updater = LandingPages::Updater.new(:git, handler)
   end
 
@@ -53,23 +45,23 @@ describe LandingPages::Updater do
     @updater.update_global(raw_global)
 
     global = LandingPages::Global.find
-    expect(global.scripts).to eq(raw_global['scripts'])
-    expect(global.footer).to eq(raw_global['footer'])
-    expect(global.header).to eq(raw_global['header'])
+    expect(global.scripts).to eq(raw_global["scripts"])
+    expect(global.footer).to eq(raw_global["footer"])
+    expect(global.header).to eq(raw_global["header"])
   end
 
   it "updates assets" do
     @updater.update_assets(raw_assets)
 
     assets = LandingPages::Asset.all
-    expect(raw_assets['register'].keys).to contain_exactly(assets.first.name, assets.second.name)
+    expect(raw_assets["register"].keys).to contain_exactly(assets.first.name, assets.second.name)
   end
 
   it "updates pages" do
-    raw_page['body'] = raw_body
+    raw_page["body"] = raw_body
     @updater.update_page(raw_page)
 
-    page = LandingPages::Page.find_by('name', raw_page['name'])
+    page = LandingPages::Page.find_by("name", raw_page["name"])
     expect(page.name).to eq(raw_page["name"])
     expect(page.path).to eq(raw_page["path"])
     expect(page.body).to eq(raw_body)

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-if ENV['SIMPLECOV']
-  require 'simplecov'
+if ENV["SIMPLECOV"]
+  require "simplecov"
 
   SimpleCov.start do
     root "plugins/discourse-landing-pages"
     track_files "plugins/discourse-landing-pages/**/*.rb"
-    add_filter { |src| src.filename =~ /(\/spec\/|\/gems\/|plugin\.rb)/ }
+    add_filter { |src| src.filename =~ %r{(/spec/|/gems/|plugin\.rb)} }
   end
 end
 
-require 'rails_helper'
+require "rails_helper"


### PR DESCRIPTION
This adds some missing configuration files and applies all required linters (`eslint`, `prettier`, `rubocop` and `stree`) to successfully validate every step of the CI pipeline.

The only non-automated change that affects code logic is in method `check_access` of file `app/controllers/landing_pages/landing.rb` to rewrite an `unless` condition as an `if` (detected as an issue by `rubocop`), everything else is purely formating.

