### PR TITLE
Formatted files related to PR #15

### DIFF
--- a/assets/javascripts/discourse/templates/components/page-admin.hbs
+++ b/assets/javascripts/discourse/templates/components/page-admin.hbs
@@ -128,13 +128,13 @@
       {{i18n "admin.landing_pages.page.theme.label"}}
     </label>
 
-    {{combo-box
-      content=themes
-      value=page.theme_id
-      onChange=(action (mut page.theme_id))
-      class="theme-select"
-      options=(hash none="admin.landing_pages.page.theme.select")
-    }}
+    <ComboBox
+      @content={{themes}}
+      @value={{page.theme_id}}
+      @onChange={{action (mut page.theme_id)}}
+      @class="theme-select"
+      @options={{hash none="admin.landing_pages.page.theme.select"}}
+    />
 
     <div class="control-instructions">
       {{i18n "admin.landing_pages.page.theme.instructions"}}
@@ -146,13 +146,13 @@
       {{i18n "admin.landing_pages.page.groups.label"}}
     </label>
 
-    {{group-chooser
-      class="group-select"
-      content=groups
-      value=page.group_ids
-      labelProperty="name"
-      onChange=(action (mut page.group_ids))
-    }}
+    <GroupChooser
+      @class="group-select"
+      @content={{groups}}
+      @value={{page.group_ids}}
+      @labelProperty="name"
+      @onChange={{action (mut page.group_ids)}}
+    />
 
     <div class="control-instructions">
       {{i18n "admin.landing_pages.page.groups.instructions"}}
@@ -168,7 +168,11 @@
       @class="category-select"
       @value={{page.category_id}}
       @onChange={{action (mut page.category_id)}}
-      @options={{hash clearable=true disabled=hasParent}}
+      @options={{hash
+        clearable=true
+        disabled=hasParent
+        none="admin.landing_pages.page.category.select"
+      }}
     />
 
     <div class="control-instructions">

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -15,7 +15,7 @@ en:
         page:
           label: "Pages"
           create: "Create"
-          select: "Select page"
+          select: "Select page…"
           export: "Export"
           remote: 
             label: "Repository"
@@ -29,13 +29,14 @@ en:
           theme:
             label: "Theme"
             instructions: "Theme with page assets"
-            select: "Select theme"
+            select: "Select theme…"
           groups:
             label: "Groups"
             instructions: "Limit access to group(s)"
           category:
             label: "Category"
             instructions: "Connect page to category (requires child pages)"
+            select: "Select category…"
           path:
             label: "Path"
             placeholder: "path"
@@ -50,13 +51,13 @@ en:
           menu:
             label: "Menu"
             instructions: "Page menu"
-            select: "Select menu"
+            select: "Select menu…"
         
         remote:
           repository:
             label: "Repository"
             description: "Update repository"
-            checking_status: "Checking status of the repository..."
+            checking_status: "Checking status of the repository…"
             not_fetched: "Please make your first pull from the repository"
             up_to_date: "Up to date with the repository"
             out_of_date: "Pull the new commits from the respository"

--- a/lib/landing_pages/page.rb
+++ b/lib/landing_pages/page.rb
@@ -62,16 +62,16 @@ class LandingPages::Page
   end
 
   def after_save
-    if self.category_id
+    if category_id
       cache = LandingPages::Cache.new(LandingPages::CATEGORY_IDS_KEY)
       category_id_map = cache.read || {}
-      category_id_map[self.category_id.to_i] = self.id
+      category_id_map[category_id] = id
       cache.write(category_id_map)
     end
   end
 
   def destroy
-    after_destroy if PluginStore.remove(LandingPages::PLUGIN_NAME, self.id)
+    after_destroy if PluginStore.remove(LandingPages::PLUGIN_NAME, id)
   end
 
   def after_destroy


### PR DESCRIPTION
This is a set of formatting changes related to the same files updated in #15. The only change that affects behaviour is the addition of a translation key to display when no category is selected for a page.

@angusmcleod as asked in the previous pull request, is this the proper way of updating the translations file? How can I align the rest of the languages to this changes? I am working also on translations for other languages (Spanish and Galician), so any guidance here will be very welcomed.