### PR TITLE
Fixed access bug for pages with no groups

### DIFF
--- a/app/controllers/landing_pages/landing.rb
+++ b/app/controllers/landing_pages/landing.rb
@@ -122,7 +122,7 @@ class LandingPages::LandingController < ::ActionController::Base
   end
 
   def check_access
-    if @page.group_ids && !@page.group_ids.include?(Group::AUTO_GROUPS[:everyone]) &&
+    if @page.group_ids.present? && !@page.group_ids.include?(Group::AUTO_GROUPS[:everyone]) &&
          (!current_user || (current_user.groups.map(&:id) & @page.group_ids).empty?)
       raise LandingPages::InvalidAccess.new
     end

--- a/spec/requests/landing_pages/landing_controller_spec.rb
+++ b/spec/requests/landing_pages/landing_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe LandingPages::LandingController do
+  fab!(:admin_user) { Fabricate(:admin) }
+
+  before do
+    LandingPages::Page.create({ name: "Public", path: "public", body: "body" })
+    LandingPages::Page.create({ name: "Private", path: "private", group_ids: [1], body: "body" })
+  end
+
+  after do
+    LandingPages::Page.find_by(:path, "public").destroy
+    LandingPages::Page.find_by(:path, "private").destroy
+  end
+
+  it "shows a public page" do
+    get "/public"
+    expect(response.status).to eq(200)
+  end
+
+  it "shows a private page if its group restrictions are met" do
+    sign_in(admin_user)
+    get "/private"
+    expect(response.status).to eq(200)
+  end
+
+  it "forbids access to a private page if its group restrictions are not met" do
+    get "/private"
+    expect(response.status).to eq(403)
+  end
+end


### PR DESCRIPTION
This updates the `check_access` condition in the `LandingController` to properly check if the page groups is a non-empty list, as Ruby considers empty arrays as truth-y values (so the explicit `present?` method is needed here).

@angusmcleod as I do not have any pending fixes I think after this PR the plugin version both in `package.json` and `plugin.rb` can be bumped to `0.3.0`, so feel free to do it manually (I can create a new PR if you prefer).