### PR TITLE
Fixed minor issues with the Blog Landing Pages repository

### DIFF
--- a/app/controllers/landing_pages/concerns/landing_helper.rb
+++ b/app/controllers/landing_pages/concerns/landing_helper.rb
@@ -13,8 +13,6 @@ module LandingHelper
   )
     return nil if user.blank?
 
-    user = User.find_by(username: username) if user.blank?
-
     if user
       bio_html = ""
       location_html = ""

--- a/app/views/landing_pages/landing/_topic_byline.html.erb
+++ b/app/views/landing_pages/landing/_topic_byline.html.erb
@@ -1,6 +1,6 @@
 <section class="topic-byline">
   <div class="author">
-    <%= user_profile(local_assigns[:topic].user, local_assigns[:user_profile_opts]) %>
+    <%= user_profile(local_assigns[:topic].user, **local_assigns[:user_profile_opts]) %>
   </div>
   <div class="bull">•</div>
   <div class="date" title="<%= short_date(local_assigns[:topic].created_at) %>">

--- a/app/views/landing_pages/landing/_topic_list_item.html.erb
+++ b/app/views/landing_pages/landing/_topic_list_item.html.erb
@@ -11,7 +11,7 @@
           </h2>
         </div>
         <section class="topic-excerpt">
-          <%= "#{local_assigns[:topic].excerpt.split[0...local_assigns[:topic_excerpt_length]].join(' ')} …" %>
+          <%== local_assigns[:topic].excerpt %>
         </section>
       </a>
       <div class="topic-meta">

--- a/lib/landing_pages/post.rb
+++ b/lib/landing_pages/post.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class ::LandingPages::Post
   def self.html(post, remove_topic_image: true)
-    fragment = Nokogiri::XML.fragment(post.cooked)
+    fragment = Nokogiri::HTML5.fragment(post.cooked)
 
     if remove_topic_image && topic_image_sha1 = post.topic&.image_upload&.sha1
       if image_node = fragment.css("a[href*='#{topic_image_sha1}']").first


### PR DESCRIPTION
This is a small update to keep the [Blog Landing Pages repository](https://github.com/paviliondev/blog-landing-pages) compatible with the current version of the plugin.