### PR TITLE
Fixed modal styles to support Discourse 3.2.0

### DIFF
--- a/assets/javascripts/discourse/components/modal/update-pages-remote.hbs
+++ b/assets/javascripts/discourse/components/modal/update-pages-remote.hbs
@@ -4,7 +4,7 @@
   @closeModal={{@closeModal}}
 >
   <:body>
-    <div class="repo">
+    <div class="url">
       <div class="label">{{i18n "admin.landing_pages.remote.url"}}</div>
       <Input @value={{buffered.url}} placeholder={{urlPlaceholder}} />
     </div>

--- a/assets/stylesheets/landing-pages-admin.scss
+++ b/assets/stylesheets/landing-pages-admin.scss
@@ -19,6 +19,7 @@
       align-items: center;
     }
 
+    .menu-select,
     .page-select {
       min-width: 300px;
       margin-right: 10px;
@@ -220,10 +221,12 @@
 }
 
 .update-pages-remote {
+  .d-modal__container,
   .modal-inner-container {
     min-width: 450px;
   }
 
+  .d-modal__footer,
   .modal-footer {
     display: flex;
     align-items: center;


### PR DESCRIPTION
This is a small fix that adds forward-compatibility with the future stable version of Discourse (3.2.0), which slightly changes the way CSS classes are generated for modals.

It allows to work both with the current stable version and the current development version of Discourse without breaking the visuals when switching between them.