### PR TITLE
Refactored landing page administration section

### DIFF
--- a/assets/javascripts/discourse/components/page-admin.js.es6
+++ b/assets/javascripts/discourse/components/page-admin.js.es6
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
+import { action } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
-import { not, notEmpty, or } from "@ember/object/computed";
+import { notEmpty, or } from "@ember/object/computed";
 import { dasherize } from "@ember/string";
 import LandingPage from "../models/landing-page";
 import { extractError } from "discourse/lib/ajax-error";
@@ -11,11 +12,29 @@ const port = location.port ? ":" + location.port : "";
 const baseUrl = location.protocol + "//" + location.hostname + port;
 
 export default Component.extend({
-  classNames: "page-admin",
   updatingPage: or("destroyingPage", "savingPage"),
   hasParent: notEmpty("parent"),
-  noParent: not("hasParent"),
-  hasPath: or("page.path", "page.parent_id"),
+
+  updateProps(props = {}) {
+    const pages = props.pages || this.pages;
+    this.set("pages", pages);
+    this.updatePages(pages);
+
+    let page;
+    if (props.page) {
+      page = LandingPage.create(props.page);
+    }
+    this.set("page", page);
+  },
+
+  showErrorMessage(error) {
+    this.set("resultMessage", {
+      style: "error",
+      icon: "times",
+      text: extractError(error),
+    });
+    setTimeout(() => this.set("resultMessage", null), 5000);
+  },
 
   @discourseComputed("page.parent_id")
   parent(parentId) {
@@ -42,100 +61,75 @@ export default Component.extend({
     return url;
   },
 
-  actions: {
-    onChangePath(path) {
-      if (!this.page.parent_id) {
-        this.set("page.path", path);
-      }
-    },
+  @action
+  onChangePath(path) {
+    if (!this.page.parent_id) {
+      this.set("page.path", path);
+    }
+  },
 
-    onChangeParent(pageId) {
-      this.set("page.parent_id", pageId);
-    },
+  @action
+  onChangeParent(pageId) {
+    this.set("page.parent_id", pageId);
+  },
 
-    savePage() {
-      this.set("savingPage", true);
+  @action
+  createPage() {
+    this.updateProps({ page: {} });
+  },
 
-      const page = this.get("page");
-      let self = this;
+  @action
+  changePage(pageId) {
+    if (pageId) {
+      LandingPage.find(pageId).then((result) => this.updateProps(result));
+    } else {
+      this.updateProps();
+    }
+  },
 
-      page
-        .savePage()
-        .then((result) => {
-          if (result.page) {
-            self.setProperties({
-              page: LandingPage.create(result.page),
-              currentPage: JSON.parse(JSON.stringify(result.page)),
-            });
-            self.updatePages(result.pages);
-          } else {
-            self.set("page", self.currentPage);
-          }
-        })
-        .catch((error) => {
-          self.set("resultMessage", {
-            type: "error",
-            icon: "times",
-            text: extractError(error),
-          });
+  @action
+  savePage() {
+    this.set("savingPage", true);
 
-          setTimeout(() => {
-            self.set("resultMessage", null);
-          }, 5000);
+    this.page
+      .save()
+      .then((result) => {
+        if (result) {
+          this.updateProps(result);
+        }
+      })
+      .catch((error) => this.showErrorMessage(error))
+      .finally(() => this.set("savingPage", false));
+  },
 
-          if (self.currentPage) {
-            self.set("page", self.currentPage);
-          }
-        })
-        .finally(() => {
-          self.set("savingPage", false);
-        });
-    },
+  @action
+  destroyPage() {
+    this.set("destroyingPage", true);
 
-    destroyPage() {
-      this.set("destroyingPage", true);
+    this.page
+      .destroy()
+      .then((result) => {
+        if (result.success) {
+          this.updateProps(result);
+        }
+      })
+      .catch((error) => this.showErrorMessage(error))
+      .finally(() => this.set("destroyingPage", false));
+  },
 
-      this.page
-        .destroyPage()
-        .then((result) => {
-          if (result.success) {
-            this.setProperties({
-              page: null,
-              pages: result.pages,
-            });
-          }
-        })
-        .finally(() => {
-          this.set("destroyingPage", false);
-        });
-    },
-
-    exportPage() {
-      const page = this.get("page");
-      let self = this;
-
-      page
-        .exportPage()
-        .then((file) => {
-          const link = document.createElement("a");
-          link.href = URL.createObjectURL(file);
-          link.setAttribute(
-            "download",
-            `discourse-${page.name.toLowerCase()}.zip`
-          );
-          link.click();
-        })
-        .catch((error) => {
-          self.set("resultMessage", {
-            type: "error",
-            icon: "times",
-            text: extractError(error),
-          });
-
-          setTimeout(() => {
-            self.set("resultMessage", null);
-          }, 5000);
-        });
-    },
+  @action
+  exportPage() {
+    this.page
+      .export()
+      .then((file) => {
+        const link = document.createElement("a");
+        link.href = URL.createObjectURL(file);
+        link.setAttribute(
+          "download",
+          `discourse-${this.page.name.toLowerCase()}.zip`
+        );
+        link.click();
+      })
+      .catch((error) => this.showErrorMessage(error));
   },
 });

--- a/assets/javascripts/discourse/controllers/admin-plugins-landing-pages.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-landing-pages.js.es6
@@ -1,4 +1,3 @@
-import LandingPage from "../models/landing-page";
 import ImportPages from "../components/modal/import-pages";
 import UpdatePagesRemote from "../components/modal/update-pages-remote";
 import Controller from "@ember/controller";
@@ -115,38 +114,17 @@ export default Controller.extend({
   },
 
   actions: {
-    changePage(pageId) {
-      if (pageId) {
-        LandingPage.find(pageId).then((result) => {
-          if (result.page) {
-            const page = LandingPage.create(result.page);
-            this.setProperties({
-              page,
-              currentPage: JSON.parse(JSON.stringify(page)),
-              showGlobal: false,
-            });
-          }
-        });
-      } else {
-        this.setProperties({
-          page: null,
-          currentPage: null,
-        });
-      }
-    },
-
-    createPage() {
-      this.set("page", LandingPage.create({ creating: true }));
-    },
-
     importPages() {
       this.modal.show(ImportPages).then((result) => {
         if (result?.page) {
-          const page = LandingPage.create(result.page);
           this.setProperties({
-            page,
-            currentPage: JSON.parse(JSON.stringify(page)),
             pages: result.pages,
+            resultMessages: {
+              type: "success",
+              messages: [
+                I18n.t("admin.landing_pages.imported.x_pages", { count: 1 }),
+              ],
+            },
           });
         }
       });
@@ -258,8 +236,6 @@ export default Controller.extend({
       this.setProperties({
         showPages: false,
         showGlobal: true,
-        page: null,
-        currentPage: null,
       });
     },
   },

--- a/assets/javascripts/discourse/controllers/admin-plugins-landing-pages.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-landing-pages.js.es6
@@ -157,8 +157,6 @@ export default Controller.extend({
             pages,
             menus,
             global,
-            page: null,
-            showGlobal: false,
           });
 
           if (report.errors.length) {
@@ -188,9 +186,9 @@ export default Controller.extend({
               }
             });
 
-            this.set("resultMessages", {
-              type: "success",
-              messages,
+            this.setProperties({
+              resultMessages: { type: "success", messages },
+              pagesNotFetched: false,
             });
 
             this.send("commitsBehind");

--- a/assets/javascripts/discourse/models/landing-page.js.es6
+++ b/assets/javascripts/discourse/models/landing-page.js.es6
@@ -8,13 +8,9 @@ const basePath = "/landing/page";
 const LandingPage = EmberObject.extend({
   exportUrl: url("id", `${basePath}/%@/export`),
 
-  savePage() {
-    const creating = this.creating;
-    let path = basePath;
-
-    if (!creating) {
-      path += `/${this.id}`;
-    }
+  save() {
+    const path = this.id ? `${basePath}/${this.id}` : basePath;
+    const method = this.id ? "PUT" : "POST";
 
     let page = {
       name: this.name,
@@ -28,19 +24,19 @@ const LandingPage = EmberObject.extend({
     };
 
     return ajax(path, {
-      type: creating ? "POST" : "PUT",
+      type: method,
       contentType: "application/json; charset=UTF-8",
       data: JSON.stringify(page),
     });
   },
 
-  destroyPage() {
+  destroy() {
     return ajax(`${basePath}/${this.id}`, {
       type: "DELETE",
     }).catch(popupAjaxError);
   },
 
-  exportPage() {
+  export() {
     return ajax(this.exportUrl, {
       type: "GET",
       dataType: "binary",

--- a/assets/javascripts/discourse/templates/admin-plugins-landing-pages.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-landing-pages.hbs
@@ -78,34 +78,11 @@
 {{#if showGlobal}}
   <GlobalAdmin @global={{global}} />
 {{else if showPages}}
-  <div class="page-controls">
-    <div class="page-list-container">
-      <ComboBox
-        @value={{page.id}}
-        @content={{pages}}
-        @onChange={{action "changePage"}}
-        class="page-select"
-        @options={{hash none="admin.landing_pages.page.select"}}
-      />
-
-      <DButton
-        @action={{action "createPage"}}
-        @label="admin.landing_pages.page.create"
-        class="page-create"
-        @icon="plus"
-      />
-    </div>
-  </div>
-
-  {{#if page}}
-    <PageAdmin
-      @page={{page}}
-      @pages={{pages}}
-      @currentPage={{currentPage}}
-      @themes={{themes}}
-      @groups={{groups}}
-      @menus={{menus}}
-      @updatePages={{action "updatePages"}}
-    />
-  {{/if}}
+  <PageAdmin
+    @pages={{pages}}
+    @themes={{themes}}
+    @groups={{groups}}
+    @menus={{menus}}
+    @updatePages={{action "updatePages"}}
+  />
 {{/if}}

--- a/assets/javascripts/discourse/templates/components/page-admin.hbs
+++ b/assets/javascripts/discourse/templates/components/page-admin.hbs
@@ -1,194 +1,215 @@
-<div class="page-header">
-  <div class="page-name">
-    <span>
-      {{#if page.name}}
-        {{page.name}}
-      {{else}}
-        {{i18n "admin.landing_pages.page.name.label"}}
-      {{/if}}
-    </span>
-  </div>
-
-  <div class="buttons">
-    {{#if resultMessage}}
-      <span class="{{resultMessage.type}}">
-        {{d-icon resultMessage.icon}}
-        {{{resultMessage.text}}}
-      </span>
-    {{/if}}
-
-    {{conditional-loading-spinner condition=updatingPage size="small"}}
-
-    {{#unless page.creating}}
-      <DButton
-        @action={{action "exportPage"}}
-        @label="admin.landing_pages.page.export"
-        @href={{page.exportUrl}}
-        @disabled={{updatingPage}}
-        @icon="upload"
-      />
-
-      <DButton
-        @action={{action "destroyPage"}}
-        @label="admin.landing_pages.destroy"
-        @disabled={{updatingPage}}
-        @icon="times"
-      />
-    {{/unless}}
-
-    <DButton
-      @action={{action "savePage"}}
-      @label="admin.landing_pages.save"
-      class="btn-primary"
-      @disabled={{updatingPage}}
-      @icon="save"
-    />
-  </div>
-
-  <div class="page-url">
-    <a href="{{pageUrl}}" target="_blank">
-      {{pageUrl}}
-      {{d-icon "external-link-alt"}}
-    </a>
-  </div>
-</div>
-
-<div class="page-details">
-  <div class="control-group">
-    <label class="control-label">
-      {{i18n "admin.landing_pages.page.name.label"}}
-    </label>
-
-    <Input @value={{page.name}} class="page-name" />
-
-    <div class="control-instructions">
-      {{i18n "admin.landing_pages.page.name.instructions"}}
-    </div>
-  </div>
-
-  <div class="control-group">
-    <label class="control-label">
-      {{i18n "admin.landing_pages.page.path.label"}}
-    </label>
-
-    <Input
-      @value={{readonly pagePath}}
-      disabled={{hasParent}}
-      onInput={{action "onChangePath" value="target.value"}}
-      class="page-path"
-    />
-
-    <div class="control-instructions">
-      {{i18n "admin.landing_pages.page.path.instructions"}}
-    </div>
-  </div>
-
-  <div class="control-group">
-    <label class="control-label">
-      {{i18n "admin.landing_pages.page.parent.label"}}
-    </label>
-
+<div class="page-controls">
+  <div class="page-list-container">
     <ComboBox
-      @value={{page.parent_id}}
+      @value={{page.id}}
       @content={{pages}}
-      @onChange={{action "onChangeParent"}}
-      class="page-select page-parent"
+      @onChange={{action "changePage"}}
+      class="page-select"
       @options={{hash none="admin.landing_pages.page.select"}}
     />
 
-    <div class="control-instructions">
-      {{i18n "admin.landing_pages.page.parent.instructions"}}
-    </div>
-  </div>
-
-  <div class="control-group">
-    <label class="control-label">
-      {{i18n "admin.landing_pages.page.menu.label"}}
-    </label>
-
-    <ComboBox
-      @content={{menus}}
-      @value={{page.menu}}
-      @valueProperty="name"
-      @nameProperty="name"
-      @onChange={{action (mut page.menu)}}
-      class="menu-select"
-      @options={{hash none="admin.landing_pages.page.menu.select"}}
+    <DButton
+      @action={{action "createPage"}}
+      @label="admin.landing_pages.create"
+      class="page-create"
+      @icon="plus"
     />
-
-    <div class="control-instructions">
-      {{i18n "admin.landing_pages.page.menu.instructions"}}
-    </div>
   </div>
 </div>
 
-<div class="page-assets">
-  <div class="control-group">
-    <label class="control-label">
-      {{i18n "admin.landing_pages.page.theme.label"}}
-    </label>
+{{#if page}}
+  <div class="page-header">
+    <div class="page-name">
+      <span>
+        {{#if page.name}}
+          {{page.name}}
+        {{else}}
+          {{i18n "admin.landing_pages.page.name.label"}}
+        {{/if}}
+      </span>
+    </div>
 
-    <ComboBox
-      @content={{themes}}
-      @value={{page.theme_id}}
-      @onChange={{action (mut page.theme_id)}}
-      @class="theme-select"
-      @options={{hash none="admin.landing_pages.page.theme.select"}}
-    />
+    <div class="buttons">
+      {{#if resultMessage}}
+        <span class="{{resultMessage.style}}">
+          {{d-icon resultMessage.icon}}
+          {{{resultMessage.text}}}
+        </span>
+      {{/if}}
 
-    <div class="control-instructions">
-      {{i18n "admin.landing_pages.page.theme.instructions"}}
+      {{conditional-loading-spinner condition=updatingPage size="small"}}
+
+      {{#if page.id}}
+        <DButton
+          @action={{action "exportPage"}}
+          @label="admin.landing_pages.page.export"
+          @href={{page.exportUrl}}
+          @disabled={{updatingPage}}
+          @icon="upload"
+        />
+
+        <DButton
+          @action={{action "destroyPage"}}
+          @label="admin.landing_pages.destroy"
+          @disabled={{updatingPage}}
+          @icon="times"
+        />
+      {{/if}}
+
+      <DButton
+        @action={{action "savePage"}}
+        @label="admin.landing_pages.save"
+        class="btn-primary"
+        @disabled={{updatingPage}}
+        @icon="save"
+      />
+    </div>
+
+    <div class="page-url">
+      <a href="{{pageUrl}}" target="_blank">
+        {{pageUrl}}
+        {{d-icon "external-link-alt"}}
+      </a>
     </div>
   </div>
 
-  <div class="control-group">
-    <label class="control-label">
-      {{i18n "admin.landing_pages.page.groups.label"}}
-    </label>
+  <div class="page-details">
+    <div class="control-group">
+      <label class="control-label">
+        {{i18n "admin.landing_pages.page.name.label"}}
+      </label>
 
-    <GroupChooser
-      @class="group-select"
-      @content={{groups}}
-      @value={{page.group_ids}}
-      @labelProperty="name"
-      @onChange={{action (mut page.group_ids)}}
-    />
+      <Input @value={{page.name}} class="page-name" />
 
-    <div class="control-instructions">
-      {{i18n "admin.landing_pages.page.groups.instructions"}}
+      <div class="control-instructions">
+        {{i18n "admin.landing_pages.page.name.instructions"}}
+      </div>
+    </div>
+
+    <div class="control-group">
+      <label class="control-label">
+        {{i18n "admin.landing_pages.page.path.label"}}
+      </label>
+
+      <Input
+        @value={{readonly pagePath}}
+        disabled={{hasParent}}
+        onInput={{action "onChangePath" value="target.value"}}
+        class="page-path"
+      />
+
+      <div class="control-instructions">
+        {{i18n "admin.landing_pages.page.path.instructions"}}
+      </div>
+    </div>
+
+    <div class="control-group">
+      <label class="control-label">
+        {{i18n "admin.landing_pages.page.parent.label"}}
+      </label>
+
+      <ComboBox
+        @value={{page.parent_id}}
+        @content={{pages}}
+        @onChange={{action "onChangeParent"}}
+        class="page-select page-parent"
+        @options={{hash none="admin.landing_pages.page.select"}}
+      />
+
+      <div class="control-instructions">
+        {{i18n "admin.landing_pages.page.parent.instructions"}}
+      </div>
+    </div>
+
+    <div class="control-group">
+      <label class="control-label">
+        {{i18n "admin.landing_pages.page.menu.label"}}
+      </label>
+
+      <ComboBox
+        @content={{menus}}
+        @value={{page.menu}}
+        @valueProperty="name"
+        @nameProperty="name"
+        @onChange={{action (mut page.menu)}}
+        class="menu-select"
+        @options={{hash none="admin.landing_pages.page.menu.select"}}
+      />
+
+      <div class="control-instructions">
+        {{i18n "admin.landing_pages.page.menu.instructions"}}
+      </div>
     </div>
   </div>
 
-  <div class="control-group">
-    <label class="control-label">
-      {{i18n "admin.landing_pages.page.category.label"}}
-    </label>
+  <div class="page-assets">
+    <div class="control-group">
+      <label class="control-label">
+        {{i18n "admin.landing_pages.page.theme.label"}}
+      </label>
 
-    <CategoryChooser
-      @class="category-select"
-      @value={{page.category_id}}
-      @onChange={{action (mut page.category_id)}}
-      @options={{hash
-        clearable=true
-        disabled=hasParent
-        none="admin.landing_pages.page.category.select"
-      }}
-    />
+      <ComboBox
+        @content={{themes}}
+        @value={{page.theme_id}}
+        @onChange={{action (mut page.theme_id)}}
+        @class="theme-select"
+        @options={{hash none="admin.landing_pages.page.theme.select"}}
+      />
 
-    <div class="control-instructions">
-      {{i18n "admin.landing_pages.page.category.instructions"}}
+      <div class="control-instructions">
+        {{i18n "admin.landing_pages.page.theme.instructions"}}
+      </div>
+    </div>
+
+    <div class="control-group">
+      <label class="control-label">
+        {{i18n "admin.landing_pages.page.groups.label"}}
+      </label>
+
+      <GroupChooser
+        @class="group-select"
+        @content={{groups}}
+        @value={{page.group_ids}}
+        @labelProperty="name"
+        @onChange={{action (mut page.group_ids)}}
+      />
+
+      <div class="control-instructions">
+        {{i18n "admin.landing_pages.page.groups.instructions"}}
+      </div>
+    </div>
+
+    <div class="control-group">
+      <label class="control-label">
+        {{i18n "admin.landing_pages.page.category.label"}}
+      </label>
+
+      <CategoryChooser
+        @class="category-select"
+        @value={{page.category_id}}
+        @onChange={{action (mut page.category_id)}}
+        @options={{hash
+          clearable=true
+          disabled=hasParent
+          none="admin.landing_pages.page.category.select"
+        }}
+      />
+
+      <div class="control-instructions">
+        {{i18n "admin.landing_pages.page.category.instructions"}}
+      </div>
     </div>
   </div>
-</div>
 
-<div class="page-editor">
-  <label class="control-label">
-    {{i18n "admin.landing_pages.page.body.label"}}
-  </label>
+  <div class="page-editor">
+    <label class="control-label">
+      {{i18n "admin.landing_pages.page.body.label"}}
+    </label>
 
-  <div class="control-instructions">
-    {{i18n "admin.landing_pages.page.body.instructions"}}
+    <div class="control-instructions">
+      {{i18n "admin.landing_pages.page.body.instructions"}}
+    </div>
+
+    <AceEditor @content={{page.body}} @mode="html" />
   </div>
-
-  <AceEditor @content={{page.body}} @mode="html" />
-</div>
+{{/if}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -11,10 +11,11 @@ en:
         documentation: "Learn more in the documentation"
         save: "Save"
         destroy: "Delete"
+        create: "Create"
 
         page:
           label: "Pages"
-          create: "Create"
+          description: "Manage all landing pages"
           select: "Select page…"
           export: "Export"
           remote: 

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -11,10 +11,11 @@ es:
         documentation: "Obtén más información en la documentación oficial"
         save: "Guardar"
         destroy: "Eliminar"
+        create: "Crear"
 
         page:
           label: "Páginas"
-          create: "Crear"
+          description: "Gestionar las páginas de aterrizaje"
           select: "Selecciona una página…"
           export: "Exportar"
           remote:

--- a/config/locales/client.gl.yml
+++ b/config/locales/client.gl.yml
@@ -11,10 +11,11 @@ gl:
         documentation: "Obtén máis información na documentación oficial"
         save: "Gardar"
         destroy: "Eliminar"
+        create: "Crear"
 
         page:
           label: "Páxinas"
-          create: "Crear"
+          description: "Xestionar as páxinas de aterraxe"
           select: "Selecciona unha página…"
           export: "Exportar"
           remote:

--- a/config/locales/client.pt.yml
+++ b/config/locales/client.pt.yml
@@ -11,10 +11,11 @@ pt:
         documentation: "Mais informações na documentação"
         save: "Salvar"
         destroy: "Excluir"
+        create: "Criar"
 
         page:
           label: "Páginas"
-          create: "Criar"
+          description: "Gerenciar as páginas de destaque"
           select: "Selecionar página"
           export: "Exportar"
           remote:


### PR DESCRIPTION
This is an attempt to simplify and better isolate all the code related to the pages section into their own self-contained files. The changes included are:

- Moving the `changePage()` and `createPage()` actions from `admin-plugins-landing-pages.js.es6` to the more specific `page-admin.js.es6`.
- Adding a message when succesfully importing a page from a ZIP file in `admin-plugins-landing-pages.js.es6` (same as when importing pages from a repository).
- Removing unused definitions, adding helper functions to extract common code and replacing the `actions` object with the recommended `@action` decorator in `page-admin.js.es6`.
- Removing the usage of `currentPage` and `page.creating` variables in favour of using the `page` object and its `page.id` attribute in `page-admin.js.es6` (possible now after the refactor).
- Moving the `page-select` combo box section from `admin-plugins-landing-pages.hbs` to the more specific `page-admin.hbs`.
- Adding a `page.description` translation to display as the tooltip for the "Pages" button.