### PR TITLE
Updated landing_helper methods for the Blog Landing pages

### DIFF
--- a/app/controllers/landing_pages/concerns/landing_helper.rb
+++ b/app/controllers/landing_pages/concerns/landing_helper.rb
@@ -86,6 +86,7 @@ module LandingHelper
 
   def topic_list(opts: {}, list_opts: {}, item_opts: {})
     list_opts[:per_page] = 30 unless list_opts[:per_page].present?
+    list_opts[:category] = -1 unless list_opts[:category].present?
     topics = list_topics(opts, list_opts)
 
     instance_variable_set("@#{opts[:instance_var]}", topics) if opts[:instance_var]
@@ -114,8 +115,14 @@ module LandingHelper
     end
   end
 
-  def set_category_user(category_slug, user: current_user)
-    if category = Category.find_by(slug: category_slug)
+  def set_parent_page(parent_id)
+    if parent_page = LandingPages::Page.find(parent_id)
+      instance_variable_set("@parent_page", parent_page)
+    end
+  end
+
+  def set_category_user(category_id, user: current_user)
+    if user && category = Category.find_by(id: category_id)
       category_user = CategoryUser.find_by(category_id: category.id, user_id: user.id)
 
       if !category_user
@@ -129,8 +136,6 @@ module LandingHelper
 
       instance_variable_set("@category_user", category_user)
     end
-
-    nil
   end
 
   def get_topic_view(id_or_slug, opts: {}, instance_var: nil, set_page_title: false)


### PR DESCRIPTION
This includes the following changes to some of the `landing_helper.rb` methods in order to make both the [Blog Landing theme](https://github.com/paviliondev/blog-landing-theme) and the [Blog Landing pages](https://github.com/paviliondev/blog-landing-pages) usable with the current version of this plugin:
- Adds a new `set_parent_page` helper method to make the parent page information accessible from the body of a child page.
- Updates the `set_category_user` helper method to find the category by identifier instead of by slug.
- Updates the `topic_list` helper method to set a default value of -1 for the category if the field is empty or not present.