### PR TITLE
Updated tester method for remotes to include valid branch

### DIFF
--- a/lib/landing_pages/import_export/git_importer.rb
+++ b/lib/landing_pages/import_export/git_importer.rb
@@ -23,8 +23,10 @@ class LandingPages::GitImporter < ThemeStore::GitImporter
           { "GIT_SSH_COMMAND" => "ssh -i #{ssh_folder}/id_rsa -o StrictHostKeyChecking=no" },
           "git",
           "ls-remote",
-          url,
           "--exit-code",
+          "--heads",
+          @url,
+          "refs/heads/#{@branch}",
         )
     rescue RuntimeError => err
       response = 2


### PR DESCRIPTION
This updates the `connected` method used to test the Git remote before importing a set of pages, to take into account both the specified URL and the branch for the validation.