### PR TITLE
Added minor improvements for page styling

### DIFF
--- a/app/views/landing_pages/landing/_header.html.erb
+++ b/app/views/landing_pages/landing/_header.html.erb
@@ -26,10 +26,12 @@
     <div class="panel">
       <span class='header-buttons'>
         <% if mobile_view? %>
-          <a class="mobile-toggle">
-            <span class="menu-icon"><%= SvgSprite.raw_svg('bars') %></span>
-            <span class="hide-menu-icon"><%= SvgSprite.raw_svg('times') %></span>
-          </a>
+          <%- if @menu.present? %>
+            <a class="mobile-toggle">
+              <span class="menu-icon"><%= SvgSprite.raw_svg('bars') %></span>
+              <span class="hide-menu-icon"><%= SvgSprite.raw_svg('times') %></span>
+            </a>
+          <%- end %>
         <% else %>
           <%- if current_user %>
             <a href="<%= path "/"%>" class='btn btn-primary forum-button'>

--- a/app/views/landing_pages/landing/_subscription_form.html.erb
+++ b/app/views/landing_pages/landing/_subscription_form.html.erb
@@ -10,11 +10,9 @@
 
   <input type="hidden" id="category_id" name="category_id" value="<%= local_assigns[:category_id] %>" />
 
-  <%= button_tag(type: "submit", class: "btn btn-primary") do %>
-    <label class="submit-label">
-      <%= local_assigns[:submit_text] || t('landing_pages.subscription.submit') %>
-    </label>
-  <% end %>
+  <button name="button" type="submit" class="btn btn-primary">
+    <%= local_assigns[:submit_text] || t('landing_pages.subscription.submit') %>
+  </button>
 
   <div class="message success-message">
     <%= local_assigns[:success_text] || t('landing_pages.subscription.success') %>

--- a/app/views/landing_pages/landing/_topic_byline.html.erb
+++ b/app/views/landing_pages/landing/_topic_byline.html.erb
@@ -7,7 +7,6 @@
     <%= short_date(local_assigns[:topic].created_at) %>
   </div>
   <% if local_assigns[:include_link] %>
-    <div class="bull">•</div>
     <a class="link" href="<%= local_assigns[:topic].url %>" target="_blank">
       <i><%= SvgSprite.raw_svg('far-comments') %></i>
       <span><%= t('landing_pages.topic_byline.link') %></span>

--- a/app/views/landing_pages/landing/_topic_list_item.html.erb
+++ b/app/views/landing_pages/landing/_topic_list_item.html.erb
@@ -11,7 +11,7 @@
           </h2>
         </div>
         <section class="topic-excerpt">
-          <%== local_assigns[:topic].excerpt %>
+          <%== emoji_codes_to_img(local_assigns[:topic].excerpt) %>
         </section>
       </a>
       <div class="topic-meta">

--- a/assets/stylesheets/page/forms.scss
+++ b/assets/stylesheets/page/forms.scss
@@ -21,6 +21,7 @@ body.landing-page {
     button {
       animation: fade-in 1s;
       display: block;
+      font-family: inherit;
     }
 
     input[type="checkbox"] {

--- a/assets/stylesheets/page/menu.scss
+++ b/assets/stylesheets/page/menu.scss
@@ -213,18 +213,82 @@ body.landing-page {
     .mobile-header .menu {
       position: fixed;
       overflow: scroll;
-      top: 6em;
-      bottom: 0;
+      top: 0;
+      bottom: 100%;
       right: 0;
       left: 0;
       visibility: hidden;
-      padding: 20px;
+      padding-top: 6em;
       background-color: white;
       flex-direction: column;
       align-items: flex-start;
+      transition: all 0.2s linear;
+
+      li.primary-item {
+        margin: 0 0 1em 0;
+        padding: 0;
+        width: 100%;
+        box-sizing: border-box;
+
+        a {
+          font-size: 1.2rem;
+        }
+
+        &:last-of-type {
+          padding-bottom: 60px;
+        }
+
+        .primary-description .more {
+          margin: 7px 0;
+        }
+      }
+
+      .primary-item-link {
+        margin-bottom: 30px;
+
+        label {
+          display: inline-block;
+          text-decoration: none;
+          font-size: 1.5rem;
+          color: $primary;
+          cursor: pointer;
+        }
+      }
 
       .menu-dropdown {
-        display: none;
+        display: flex;
+        visibility: hidden;
+        flex-direction: column;
+        position: relative;
+        top: initial;
+        padding: 0;
+
+        .menu-item-list {
+          display: flex;
+          flex-wrap: wrap;
+          gap: unset;
+          margin: 15px 0;
+
+          li.item {
+            width: 100%;
+            padding: 0;
+            margin: 1.5em 0;
+
+            a .image {
+              float: left;
+              margin-right: 0.8rem;
+              background-position: initial;
+            }
+
+            .content {
+              display: flex;
+
+              .label {
+                margin-top: 0;
+              }
+            }
+          }
+        }
       }
     }
 
@@ -232,85 +296,11 @@ body.landing-page {
       overflow: hidden;
 
       .mobile-header .menu {
+        bottom: 0;
         visibility: visible;
-        overflow: scroll;
-        padding: 2em;
-
-        li.primary-item {
-          margin: 0 0 1em 0;
-          padding: 0;
-          width: 100%;
-          box-sizing: border-box;
-
-          a {
-            font-size: 1.2rem;
-          }
-
-          &:last-of-type {
-            padding-bottom: 60px;
-          }
-
-          .primary-description .more {
-            margin: 7px 0;
-          }
-        }
-
-        .primary-item-link {
-          margin-bottom: 30px;
-
-          label {
-            display: inline-block;
-            background-image: linear-gradient(
-              180deg,
-              transparent 90%,
-              $tertiary 0
-            );
-            background-size: 100% 100%;
-            background-repeat: no-repeat;
-            text-decoration: none;
-            font-size: 1.5rem;
-            color: $primary;
-            transition: background-size 0.4s ease;
-            cursor: pointer;
-          }
-        }
 
         .menu-dropdown {
-          display: flex;
           visibility: visible;
-          flex-direction: column;
-          position: relative;
-          top: initial;
-          padding: 0;
-
-          .menu-item-list {
-            display: flex;
-            flex-wrap: wrap;
-            gap: unset;
-            margin: 15px 0;
-
-            li.item {
-              width: 100%;
-              backface-visibility: visible;
-              opacity: 1;
-              padding: 0;
-              margin: 1.5em 0;
-
-              a .image {
-                float: left;
-                margin-right: 0.8rem;
-                background-position: initial;
-              }
-
-              .content {
-                display: flex;
-
-                .label {
-                  margin-top: 0;
-                }
-              }
-            }
-          }
         }
       }
     }

--- a/assets/stylesheets/page/topic.scss
+++ b/assets/stylesheets/page/topic.scss
@@ -18,12 +18,14 @@ body.landing-page {
 
     .bull {
       opacity: 0.6;
-      padding: 0.5em 1em;
+      padding: 0.2em 0.5em;
     }
 
     .link {
       display: flex;
       align-items: center;
+      flex: 1;
+      justify-content: right;
 
       i {
         display: flex;

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,12 +9,12 @@ en:
       error: "Oops, that didn't work. Give it another shot."
 
     subscription:
-      label: "Subscribe to %{site}'s posts."
-      description: "You'll get an email when we make a new post."
+      label: "Subscribe to %{site}'s posts"
+      description: "You'll get an email when we make a new post"
       submit: "Submit"
-      success: "Subscription Updated"
+      success: "Subscription updated"
       error: "Oops, that didn't work. Give it another shot."
-      read_more: "Read More"
+      read_more: "Read more"
 
     error:
       attr_required: "%{attr} required"
@@ -25,7 +25,7 @@ en:
       import_json: "%{path} json is invalid: %{error}"
 
     topic_byline:
-      link: "Forum Topic"
+      link: "Forum topic"
     
   contact_mailer:
     title: "New Contact"

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -9,7 +9,7 @@ es:
       error: "¡Ups! Algo no ha ido bien, inténtalo de nuevo."
 
     subscription:
-      label: "Suscríbete a los posts de %{site}."
+      label: "Suscríbete a los posts de %{site}"
       description: "Recibirás un correo electrónico cuando publiquemos un nuevo post"
       submit: "Enviar"
       success: "Suscripción actualizada"

--- a/config/locales/server.gl.yml
+++ b/config/locales/server.gl.yml
@@ -9,7 +9,7 @@ gl:
       error: "¡Ups! Algo non foi bien, téntao de novo."
 
     subscription:
-      label: "Suscríbeche aos posts de %{site}."
+      label: "Suscríbeche aos posts de %{site}"
       description: "Recibirás un correo electrónico cando publiquemos un novo post"
       submit: "Enviar"
       success: "Subscripción actualizada"

--- a/config/locales/server.pt.yml
+++ b/config/locales/server.pt.yml
@@ -9,12 +9,12 @@ pt:
       error: "Ops, isso não funcionou. Dê uma nova jogada."
 
     subscription:
-      label: "Inscreva-se para as publicações de %{site}."
-      description: "Você receberá um e-mail quando criarmos um novo post."
+      label: "Inscreva-se para as publicações de %{site}"
+      description: "Você receberá um e-mail quando criarmos um novo post"
       submit: "Submeter"
       success: "Assinatura atualizada"
       error: "Ops, isso não funcionou. Tente outra vez."
-      read_more: "Leia Mais"
+      read_more: "Leia mais"
 
     error:
       attr_required: "%{attr} é necessário"


### PR DESCRIPTION
This updates the page styles and templates with the following improvements:
- Top left menu in mobile view only appears when there is a menu configured. Its styling has been simplified and its visibility is based on the `bottom` property now.
- Submit subscription button inherits the base font.
- Link in topic byline is now separated from author and date without a bullet (right-aligned in desktop view, different line in mobile view).
- Topic excerpts now render emojis.
- Translations for the subscription modal have their capitalization standardized.

Relates to paviliondev/blog-landing-theme#4 and paviliondev/blog-landing-pages#2.