### PR TITLE
FEATURE: Support new Discourse Home Pages Theme Component for highly integrated presentation

### DIFF
--- a/app/controllers/landing_pages/landing.rb
+++ b/app/controllers/landing_pages/landing.rb
@@ -50,6 +50,10 @@ class LandingPages::LandingController < ::ActionController::Base
     end
   end
 
+  def path(p)
+    "#{Discourse.base_url}#{p}"
+  end
+
   def visit_from_crawler?
       request.user_agent && (request.media_type.blank? || request.media_type.include?("html")) &&
         !%w[json rss].include?(params[:format]) &&

--- a/app/controllers/landing_pages/landing.rb
+++ b/app/controllers/landing_pages/landing.rb
@@ -36,7 +36,11 @@ class LandingPages::LandingController < ::ActionController::Base
         @footer = @global.footer if @global.footer.present?
       end
 
-      render inline: @page.body, layout: "landing"
+      if request.format == "json"
+        render json: { page: @page.body }
+      else
+        render inline: @page.body, layout: "landing"
+      end
     else
       redirect_to path("/")
     end

--- a/app/controllers/landing_pages/landing.rb
+++ b/app/controllers/landing_pages/landing.rb
@@ -42,7 +42,7 @@ class LandingPages::LandingController < ::ActionController::Base
         if !SiteSetting.landing_redirect_to_homepages || visit_from_crawler?
           render inline: @page.body, layout: "landing"
         else
-          redirect_to path("/#{SiteSetting.landing_redirect_to_homepages_root_path}/#{params[:path].split("/").last}")
+          redirect_to path("/#{SiteSetting.landing_redirect_to_homepages_root_path}/#{request.path.split("/").last}")
         end
       end
     else

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -37,4 +37,4 @@ en:
     landing_contact_email: "Email to send landing page contacts to."
     landing_authorized_extensions: "Authorized file extensions for landing pages."
     landing_redirect_to_homepages: "Redirect to landing pages to be consumed and presented by Home Pages Theme Component."
-    landing_redirect_to_homepages_root_path: "Root path for Home Pages Theme Component."
+    landing_redirect_to_homepages_root_path: "Root path for Landing Pages when presented via Home Pages Theme Component."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -36,3 +36,5 @@ en:
   site_settings:
     landing_contact_email: "Email to send landing page contacts to."
     landing_authorized_extensions: "Authorized file extensions for landing pages."
+    landing_redirect_to_homepages: "Redirect to landing pages to be consumed and presented by Home Pages Theme Component."
+    landing_redirect_to_homepages_root_path: "Root path for Home Pages Theme Component."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,4 +9,4 @@ plugins:
     default: false
     type: boolean
   landing_redirect_to_homepages_root_path:
-    default: '/discourse-home-pages/page'
+    default: '/discourse-home-pages/landing-page'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,4 +9,4 @@ plugins:
     default: false
     type: boolean
   landing_redirect_to_homepages_root_path:
-    default: '/discourse-home-pages/landing-page'
+    default: '/home-pages/sp'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,8 @@ plugins:
     default: "jpg|jpeg|png|woff|woff2|svg|eot|ttf|otf|gif|js|json"
     type: list
     list_type: compact
+  landing_redirect_to_homepages:
+    default: false
+    type: boolean
+  landing_redirect_to_homepages_root_path:
+    default: '/discourse-home-pages/page'

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 
 # name: discourse-landing-pages
 # about: Adds landing pages to Discourse
-# version: 0.3.0
+# version: 0.3.1
 # authors: Angus McLeod, Pablo Cabido
 # url: https://github.com/paviliondev/discourse-landing-pages
 

--- a/spec/requests/landing_pages/landing_controller_spec.rb
+++ b/spec/requests/landing_pages/landing_controller_spec.rb
@@ -42,7 +42,7 @@ describe LandingPages::LandingController do
     expect(response.parsed_body["body"]).to eq("body")
   end
 
-  it "shows the normal page if the user agent is a bot even if redirect to Home Page TC is set" do
+  it "shows the normal page if redirect to Home Page TC is set to false" do
     SiteSetting.landing_redirect_to_homepages = false
     get "/public"
     expect(response.status).to eq(200)

--- a/spec/requests/landing_pages/landing_controller_spec.rb
+++ b/spec/requests/landing_pages/landing_controller_spec.rb
@@ -28,4 +28,24 @@ describe LandingPages::LandingController do
     get "/private"
     expect(response.status).to eq(403)
   end
+
+  it "sends back a json representation of the page" do
+    get "/public.json"
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["page"]["body"]).to eq("body")
+  end
+
+  it "shows the normal page if the user agent is a bot even if redirect to Home Page TC is set" do
+    SiteSetting.landing_redirect_to_homepages = true
+    get "/public", headers: { "HTTP_USER_AGENT" => "Googlebot" }
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["body"]).to eq("body")
+  end
+
+  it "shows the normal page if the user agent is a bot even if redirect to Home Page TC is set" do
+    SiteSetting.landing_redirect_to_homepages = false
+    get "/public"
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["body"]).to eq("body")
+  end
 end


### PR DESCRIPTION
* FEATURE: show content within the standard layout of Discourse site including standard header and sidebar
* FEATURE: users are optionally redirected to the integrated version
* FEATURE: crawlers continue to see standard landing pages
* PRE-REQUISITES:
  * The Home Pages Plugin (which could be folded in to this plugin to avoid complexity of install):  https://github.com/merefield/discourse-home-pages
  * The Home Pages Theme Component (which does most of the work: https://github.com/merefield/discourse-tc-home-pages

This works by adding a json only endpoint to Landing Pages to return the html within a json object that can be inserted by the Theme Component.  The Home Pages Plugin exists only to provide valid routes for the TC.

See this Topic: https://coop.pavilion.tech/t/experimental-the-home-pages-add-on-integrate-static-content-from-landing-pages-and-add-dynamic-pages-too/3554?u=merefield