### PR TITLE
Updated Github Action runs

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   ci:
     uses: discourse/.github/.github/workflows/discourse-plugin.yml@v1
+    with:
+      core_ref: v3.2.3

--- a/app/controllers/landing_pages/landing.rb
+++ b/app/controllers/landing_pages/landing.rb
@@ -42,7 +42,9 @@ class LandingPages::LandingController < ::ActionController::Base
         if !SiteSetting.landing_redirect_to_homepages || visit_from_crawler?
           render inline: @page.body, layout: "landing"
         else
-          redirect_to path("/#{SiteSetting.landing_redirect_to_homepages_root_path}/#{request.path.split("/").last}")
+          homepages_root_path =
+            "/#{SiteSetting.landing_redirect_to_homepages_root_path}/#{request.path.split("/").last}"
+          redirect_to path(homepages_root_path)
         end
       end
     else
@@ -55,9 +57,9 @@ class LandingPages::LandingController < ::ActionController::Base
   end
 
   def visit_from_crawler?
-      request.user_agent && (request.media_type.blank? || request.media_type.include?("html")) &&
-        !%w[json rss].include?(params[:format]) &&
-        CrawlerDetection.crawler?(request.user_agent, request.headers["HTTP_VIA"])
+    request.user_agent && (request.media_type.blank? || request.media_type.include?("html")) &&
+      !%w[json rss].include?(params[:format]) &&
+      CrawlerDetection.crawler?(request.user_agent, request.headers["HTTP_VIA"])
   end
 
   def contact


### PR DESCRIPTION
This removes the scheduled timer for the Github Action, enables manual runs and sets a fixed Discourse version (currently the latest stable) for better consistency between tests. It also updates 2 minor linting issues detected by the action.

@angusmcleod @merefield I think the action was disabled a few months ago due to the scheduler, can any of you enable it again to ensure that it runs on pull requests again?